### PR TITLE
[WIP] Update how systemd is used to have multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ zypper in hanadb_exporter
 ```
 
 Even using this way, the SAP HANA database connector package must be installed independently (see [Installation](#installation)).
-After that we need to create the configuration file as `/etc/hanadb_exporter/config.json`.
+
+After that we need to create the configuration file as `/etc/hanadb_exporter/my-exporter.json` (the name is relevant as we will use it to start the daemon).
 The [config.json.example](./config.json.example) can be used as example (the example file is
 stored in `/etc/hanadb_exporter` folder too).
 
@@ -83,12 +84,12 @@ The default [metrics file](./metrics.json) is stored in `/etc/hanadb_exporter/me
 
 The logging configuration file can be updated as well to customize it (stored in `/etc/hanadb_exporter/logging_config.ini`)
 
-Now, the exporter can be started as a daemon:
+Now, the exporter can be started as a daemon. As we can have multiple `hanadb_exporter` instances running in one machine, the service is created using a template file, so an extra information must be given to `systemd` (this is done adding the `@` keyword after the service name together with the name of the configuration file created previously in `/etc/hanadb_exporter/{name}.json`):
 ```
 # All the command must be executed as root user
-systemctl start hanadb_exporter
+systemctl start hanadb_exporter@my-exporter
 # Check the status with
-systemctl status hanadb_exporter
+systemctl status hanadb_exporter@my-exporter
 ```
 
 ## License

--- a/daemon/hanadb_exporter.sysconfig
+++ b/daemon/hanadb_exporter.sysconfig
@@ -1,5 +1,3 @@
 # hanadb_exporter daemon configuration file
-# Exporter configuration file path
-CONFIG_FILE=/etc/hanadb_exporter/config.json
 # Exported metrics configuration file path
 METRICS_FILE=/etc/hanadb_exporter/metrics.json

--- a/daemon/hanadb_exporter@.service
+++ b/daemon/hanadb_exporter@.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/SUSE/hanadb_exporter
 [Service]
 Type=simple
 EnvironmentFile=/etc/sysconfig/hanadb_exporter
-ExecStart=/usr/bin/hanadb_exporter -c $CONFIG_FILE -m $METRICS_FILE
+ExecStart=/usr/bin/hanadb_exporter -c /etc/hanadb_exporter/%i.json -m $METRICS_FILE
 
 [Install]
 WantedBy=multi-user.target

--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul  3 07:40:46 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
+
+- Version 0.3.1 updating how the exporter is executed as a daemon 
+
+-------------------------------------------------------------------
 Tue Jul  2 09:19:00 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Version 0.3.0 created

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -62,7 +62,7 @@ rm -r %{buildroot}%{python3_sitelib}/tests
 
 # Add daemon files
 mkdir -p %{buildroot}%{_sysconfdir}/hanadb_exporter
-install -D -m 644 daemon/hanadb_exporter.service %{buildroot}%{_unitdir}/hanadb_exporter.service
+install -D -m 644 daemon/hanadb_exporter@.service %{buildroot}%{_unitdir}/hanadb_exporter@.service
 
 mkdir -p %{buildroot}%{_fillupdir}
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
@@ -72,7 +72,7 @@ install -D -m 0644 metrics.json %{buildroot}%{_docdir}/hanadb_exporter/metrics.j
 install -D -m 0644 logging_config.ini %{buildroot}%{_docdir}/hanadb_exporter/logging_config.ini
 
 %post
-%service_add_post hanadb_exporter.service
+%service_add_post hanadb_exporter@.service
 if [ ! -e %{_sysconfdir}/sysconfig/hanadb_exporter ]; then
     %fillup_only hanadb_exporter
 fi
@@ -82,13 +82,13 @@ ln -s %{_docdir}/hanadb_exporter/metrics.json  %{_sysconfdir}/hanadb_exporter/me
 ln -s %{_docdir}/hanadb_exporter/logging_config.ini  %{_sysconfdir}/hanadb_exporter/logging_config.ini
 
 %pre
-%service_add_pre hanadb_exporter.service
+%service_add_pre hanadb_exporter@.service
 
 %preun
-%service_del_preun -n hanadb_exporter.service
+%service_del_preun -n hanadb_exporter@.service
 
 %postun
-%service_del_postun -n hanadb_exporter.service
+%service_del_postun -n hanadb_exporter@.service
 
 %if %{with test}
 %check
@@ -110,6 +110,6 @@ pytest tests
 %{_docdir}/hanadb_exporter/metrics.json
 %{_docdir}/hanadb_exporter/logging_config.ini
 %{_fillupdir}/sysconfig.hanadb_exporter
-%{_unitdir}/hanadb_exporter.service
+%{_unitdir}/hanadb_exporter@.service
 
 %changelog

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -26,7 +26,7 @@
 %endif
 
 Name:           hanadb_exporter
-Version:        0.3.0
+Version:        0.3.1
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
Before, only one instance of the exporter could be started in the same machine. 
As we can have more than one instance this has to be updated.

This PR updates the systemd usage and how the exporter is executed as a daemon