### PR TITLE
Mock modules import to adapt the test to obs check

### DIFF
--- a/hanadb_exporter/exporters/prometheus_exporter.py
+++ b/hanadb_exporter/exporters/prometheus_exporter.py
@@ -13,7 +13,7 @@ import logging
 try:
     # pylint:disable=W0622
     from itertools import izip as zip
-except ImportError:
+except ImportError: # pragma: no cover
     pass
 
 # TODO: In order to avoid dependencies, import custom prometheus client

--- a/tests/exporter_factory_test.py
+++ b/tests/exporter_factory_test.py
@@ -23,6 +23,8 @@ except ImportError:
 
 import pytest
 
+sys.modules['prometheus_client'] = mock.MagicMock()
+
 from hanadb_exporter import exporter_factory
 
 

--- a/tests/exporters/prometheus_exporter_test.py
+++ b/tests/exporters/prometheus_exporter_test.py
@@ -23,6 +23,8 @@ except ImportError:
 
 import pytest
 
+sys.modules['prometheus_client'] = mock.MagicMock()
+
 from hanadb_exporter.exporters import prometheus_exporter
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -23,7 +23,9 @@ except ImportError:
 
 import pytest
 
-sys.modules['shaptools'] = mock.Mock()
+sys.modules['shaptools'] = mock.MagicMock()
+sys.modules['prometheus_client'] = mock.MagicMock()
+sys.modules['prometheus_client.core'] = mock.MagicMock()
 
 from hanadb_exporter import main
 


### PR DESCRIPTION
Update the tests as they failed in OBS.
Now the third party libraries are mocked to avoid issues in imports