### PR TITLE
Feature/check hana version

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -9,7 +9,8 @@ to create the correct structure:
 
 Each entry in the JSON file is formed by a SAP HANA SQL query (key) and the metrics/additional information (value). The additional information is composed by:
 
-* `enabled (boolean, optional)`: If the query is executed or not (`true` by default is the `enabled` entry is not set). If set to `false` the metrics for this query won't be exported.
+* `enabled (boolean, optional)`: If the query is executed or not (`true` by default is the `enabled` entry is not set). If set to `false` the metrics for this query won't be executed.
+* `hana_version (str, optional)`: The SAP HANA database version since the query is available (`1.0` by default). If the current database version is lower than provided version, the query won't be executed.
 * `metrics (list)`: A list of metrics for this query. Each metric will need the next information;
 * `name (str):`: The name used to export the metric.
 * `description (str)`: The description of the metric (available as `# HELP`).
@@ -25,6 +26,7 @@ Here an example of a query and some metrics:
   "SELECT TOP 10 host, LPAD(port, 5) port, SUBSTRING(REPLACE_REGEXPR('\n' IN statement_string WITH ' ' OCCURRENCE ALL), 1,30) sql_string, statement_hash sql_hash, execution_count, total_execution_time + total_preparation_time total_elapsed_time FROM sys.m_sql_plan_cache ORDER BY total_elapsed_time, execution_count DESC;":
   {
     "enabled": true,
+    "hana_version": "1.0"
     "metrics": [
       {
         "name": "hanadb_sql_top_time_consumers",

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -10,7 +10,7 @@ to create the correct structure:
 Each entry in the JSON file is formed by a SAP HANA SQL query (key) and the metrics/additional information (value). The additional information is composed by:
 
 * `enabled (boolean, optional)`: If the query is executed or not (`true` by default is the `enabled` entry is not set). If set to `false` the metrics for this query won't be executed.
-* `hana_version (str, optional)`: The SAP HANA database version since the query is available (`1.0` by default). If the current database version is lower than provided version, the query won't be executed.
+* `hana_version_range (list, optional)`: The SAP HANA database versions range where the query is available (`[1.0.0]` by default). If the current database version is not inside the provided range, the query won't be executed. If the list has only one element, all versions beyond this value (this included) will be queried.
 * `metrics (list)`: A list of metrics for this query. Each metric will need the next information;
 * `name (str):`: The name used to export the metric.
 * `description (str)`: The description of the metric (available as `# HELP`).
@@ -26,7 +26,7 @@ Here an example of a query and some metrics:
   "SELECT TOP 10 host, LPAD(port, 5) port, SUBSTRING(REPLACE_REGEXPR('\n' IN statement_string WITH ' ' OCCURRENCE ALL), 1,30) sql_string, statement_hash sql_hash, execution_count, total_execution_time + total_preparation_time total_elapsed_time FROM sys.m_sql_plan_cache ORDER BY total_elapsed_time, execution_count DESC;":
   {
     "enabled": true,
-    "hana_version": "1.0"
+    "hana_version_range": ["1.0"]
     "metrics": [
       {
         "name": "hanadb_sql_top_time_consumers",

--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul  9 09:56:38 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
+
+- Version 0.3.2 adding the option to filter the queries by current
+SAP HANA database version 
+
+-------------------------------------------------------------------
 Wed Jul  3 07:40:46 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Version 0.3.1 updating how the exporter is executed as a daemon 

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -26,7 +26,7 @@
 %endif
 
 Name:           hanadb_exporter
-Version:        0.3.1
+Version:        0.3.2
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/hanadb_exporter/exporters/prometheus_metrics.py
+++ b/hanadb_exporter/exporters/prometheus_metrics.py
@@ -15,7 +15,7 @@ import json
 
 METRICMODEL = collections.namedtuple(
     'Metric',
-    'name description labels value unit type enabled hana_version'
+    'name description labels value unit type enabled hana_version_range'
 )
 
 
@@ -27,9 +27,14 @@ class Metric(METRICMODEL):
     # pylint:disable=R0913
     # pylint:disable=W0622
     def __new__(
-            cls, name, description, labels, value, unit, type, enabled=True, hana_version="1.0"):
+            cls, name, description, labels, value, unit, type,
+            enabled=True, hana_version_range=None):
+        if not value:
+            raise ValueError('No value specified in metrics.json for {}'.format(name))
+        if not hana_version_range:
+            hana_version_range = ['1.0.0']
         return super(Metric, cls).__new__(
-            cls, name, description, labels, value, unit, type, enabled, hana_version)
+            cls, name, description, labels, value, unit, type, enabled, hana_version_range)
 
 
 class Query(object):
@@ -41,7 +46,7 @@ class Query(object):
         self.query = None
         self.metrics = []
         self.enabled = True
-        self.hana_version = '1.0.0.0'
+        self.hana_version_range = ['1.0.0']
 
     def parse(self, query, query_data):
         """
@@ -50,7 +55,7 @@ class Query(object):
         self.query = query
         self.metrics = []
         self.enabled = query_data.get('enabled', True)
-        self.hana_version = query_data.get('hana_version', '1.0.0.0')
+        self.hana_version_range = query_data.get('hana_version', ['1.0.0'])
         for metric in query_data['metrics']:
             modeled_data = Metric(**metric)
             self.metrics.append(modeled_data)

--- a/hanadb_exporter/exporters/prometheus_metrics.py
+++ b/hanadb_exporter/exporters/prometheus_metrics.py
@@ -15,7 +15,7 @@ import json
 
 METRICMODEL = collections.namedtuple(
     'Metric',
-    'name description labels value unit type enabled'
+    'name description labels value unit type enabled hana_version'
 )
 
 
@@ -26,9 +26,10 @@ class Metric(METRICMODEL):
 
     # pylint:disable=R0913
     # pylint:disable=W0622
-    def __new__(cls, name, description, labels, value, unit, type, enabled=True):
+    def __new__(
+            cls, name, description, labels, value, unit, type, enabled=True, hana_version="1.0"):
         return super(Metric, cls).__new__(
-            cls, name, description, labels, value, unit, type, enabled)
+            cls, name, description, labels, value, unit, type, enabled, hana_version)
 
 
 class Query(object):
@@ -40,6 +41,7 @@ class Query(object):
         self.query = None
         self.metrics = []
         self.enabled = True
+        self.hana_version = '1.0.0.0'
 
     def parse(self, query, query_data):
         """
@@ -48,6 +50,7 @@ class Query(object):
         self.query = query
         self.metrics = []
         self.enabled = query_data.get('enabled', True)
+        self.hana_version = query_data.get('hana_version', '1.0.0.0')
         for metric in query_data['metrics']:
             modeled_data = Metric(**metric)
             self.metrics.append(modeled_data)

--- a/hanadb_exporter/utils.py
+++ b/hanadb_exporter/utils.py
@@ -1,0 +1,29 @@
+"""
+Generic methods
+
+:author: xarbulu
+:organization: SUSE Linux GmbH
+:contact: xarbulu@suse.de
+
+:since: 2019-07-04
+"""
+
+# TODO: this method could go in shaptools itself, providng the query return formatted if
+# it is requested (returning a list of dictionaries like this method)
+def format_query_result(query_result):
+    """
+    Format query results to match column names with their values for each row
+    Returns: list containing a dictionaries (column_name, value)
+
+    Args:
+        query_result (obj): QueryResult object
+    """
+    formatted_query_result = []
+    query_columns = [meta[0] for meta in query_result.metadata]
+    for record in query_result.records:
+        record_data = {}
+        for index, record_item in enumerate(record):
+            record_data[query_columns[index]] = record_item
+
+        formatted_query_result.append(record_data)
+    return formatted_query_result

--- a/hanadb_exporter/utils.py
+++ b/hanadb_exporter/utils.py
@@ -8,7 +8,9 @@ Generic methods
 :since: 2019-07-04
 """
 
-# TODO: this method could go in shaptools itself, providng the query return formatted if
+from distutils import version
+
+# TODO: this method could go in shaptools itself, providing the query return formatted if
 # it is requested (returning a list of dictionaries like this method)
 def format_query_result(query_result):
     """
@@ -27,3 +29,24 @@ def format_query_result(query_result):
 
         formatted_query_result.append(record_data)
     return formatted_query_result
+
+
+def check_hana_range(hana_version, availability_range):
+    """
+    Check if the current hana version is inside the available range
+
+    Args:
+        hana_version (str): Current hana version
+        availability_range (list): List with one or two elements definining the
+            available hana versions
+
+    Returns:
+        bool: True if the current hana version is inside the availability range
+    """
+
+    if len(availability_range) == 1:
+        return version.LooseVersion(hana_version) >= version.LooseVersion(availability_range[0])
+    elif len(availability_range) == 2:
+        return version.LooseVersion(hana_version) >= version.LooseVersion(availability_range[0]) \
+            and version.LooseVersion(hana_version) <= version.LooseVersion(availability_range[1])
+    raise ValueError('provided availability range does not have the correct number of elements')

--- a/metrics.json
+++ b/metrics.json
@@ -2,6 +2,7 @@
   "SELECT host, ROUND(SUM(memory_size_in_total)/1024/1024) column_tables_used_mb FROM sys.m_cs_tables GROUP BY host;":
   {
     "enabled": true,
+    "hana_version": "1.0",
     "metrics": [
       {
         "name": "hanadb_column_tables_used_memory",

--- a/metrics.json
+++ b/metrics.json
@@ -2,7 +2,7 @@
   "SELECT host, ROUND(SUM(memory_size_in_total)/1024/1024) column_tables_used_mb FROM sys.m_cs_tables GROUP BY host;":
   {
     "enabled": true,
-    "hana_version": "1.0",
+    "hana_version_range": ["1.0.0", "3.0.0"],
     "metrics": [
       {
         "name": "hanadb_column_tables_used_memory",
@@ -16,6 +16,7 @@
   },
   "SELECT host, schema_name, ROUND(SUM(memory_size_in_total)/1024/1024) schema_memory_used_mb FROM sys.m_cs_tables GROUP BY host, schema_name;":
   {
+    "hana_version_range": ["1.0.0"],
     "metrics": [
       {
         "name": "hanadb_schema_used_memory",

--- a/tests/exporter_factory_test.py
+++ b/tests/exporter_factory_test.py
@@ -33,22 +33,45 @@ class TestSapHanaExporter(object):
     Unitary tests for hanadb_exporter/exporter_factory.py.
     """
 
+    @mock.patch('hanadb_exporter.utils.format_query_result')
+    def test_get_hana_version(self, mock_format_query):
+        mock_connector = mock.Mock()
+        mock_connector.query.return_value = 'query_result'
+        mock_format_query.return_value = [{'VERSION': '2.0'}]
+        version = exporter_factory.SapHanaExporter.get_hana_version(mock_connector)
+
+        mock_connector.query.assert_called_once_with('SELECT * FROM sys.m_database;')
+        mock_format_query.assert_called_once_with('query_result')
+        assert version == '2.0'
+
     @mock.patch('hanadb_exporter.exporters.prometheus_exporter.SapHanaCollector')
+    @mock.patch('hanadb_exporter.exporter_factory.SapHanaExporter.get_hana_version')
     @mock.patch('logging.Logger.info')
-    def test_create(self, mock_logger, mock_hana_collector):
+    def test_create(self, mock_logger, mock_get_hana, mock_hana_collector):
         mocked_collector = mock.Mock()
         mock_connector = mock.Mock()
         mock_hana_collector.return_value = mocked_collector
+        mock_get_hana.return_value = '2.0'
         collector = exporter_factory.SapHanaExporter.create(
             exporter_type='prometheus', hdb_connector=mock_connector, metrics_file='metrics.json')
 
-        mock_logger.assert_called_once_with('prometheus exporter selected')
+        mock_get_hana.assert_called_once_with(mock_connector)
+        mock_hana_collector.assert_called_once_with(
+            connector=mock_connector,
+            metrics_file='metrics.json',
+            hana_version='2.0')
+        mock_logger.assert_has_calls([
+            mock.call('SAP HANA database version: %s', '2.0'),
+            mock.call('prometheus exporter selected')
+        ])
         assert collector == mocked_collector
 
-    def test_create_error(self):
+    @mock.patch('hanadb_exporter.exporter_factory.SapHanaExporter.get_hana_version')
+    def test_create_error(self, mock_get_hana):
         mock_connector = mock.Mock()
         with pytest.raises(NotImplementedError) as err:
             exporter_factory.SapHanaExporter.create(
                 exporter_type='other', hdb_connector=mock_connector, metrics_file='metrics.json')
 
+        mock_get_hana.assert_called_once_with(mock_connector)
         assert '{} exporter not implemented'.format('other') in str(err.value)

--- a/tests/exporters/prometheus_metrics_test.py
+++ b/tests/exporters/prometheus_metrics_test.py
@@ -47,6 +47,7 @@ class TestMetric(object):
         assert modeled_metric.unit == 'unit'
         assert modeled_metric.type == 'type'
         assert modeled_metric.enabled == True
+        assert modeled_metric.hana_version_range == ['1.0.0']
 
         correct_data = {
             'name': 'name',
@@ -55,7 +56,8 @@ class TestMetric(object):
             'value': 'value',
             'unit': 'unit',
             'type': 'type',
-            'enabled': False
+            'enabled': False,
+            'hana_version_range': ['1.0.0', '2.0.0']
         }
 
         modeled_metric = prometheus_metrics.Metric(**correct_data)
@@ -66,6 +68,7 @@ class TestMetric(object):
         assert modeled_metric.unit == 'unit'
         assert modeled_metric.type == 'type'
         assert modeled_metric.enabled == False
+        assert modeled_metric.hana_version_range == ['1.0.0', '2.0.0']
 
         missing_data = {
             'name': 'name',
@@ -102,6 +105,20 @@ class TestMetric(object):
         with pytest.raises(TypeError) as err:
             modeled_metric = prometheus_metrics.Metric(**missing_data)
 
+    def test_metric_new_error(self):
+        correct_data = {
+            'name': 'name',
+            'description': 'description',
+            'labels': list(),
+            'value': '',
+            'unit': 'unit',
+            'type': 'type'
+        }
+
+        with pytest.raises(ValueError) as err:
+            prometheus_metrics.Metric(**correct_data)
+
+        assert 'No value specified in metrics.json for {}'.format('name') in str(err.value)
 
 class TestQuery(object):
     """

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,52 @@
+"""
+Unitary tests for utils.py.
+
+:author: xarbulu
+:organization: SUSE Linux GmbH
+:contact: xarbulu@suse.com
+
+:since: 2019-07-05
+"""
+
+# pylint:disable=C0103,C0111,W0212,W0611
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import logging
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import pytest
+
+sys.modules['prometheus_client'] = mock.MagicMock()
+
+from hanadb_exporter import utils
+
+
+class TestUtils(object):
+    """
+    Unitary tests for utils.
+    """
+
+
+    def test_format_query_result(self):
+        query_results = mock.Mock()
+        query_results.metadata = [
+            ('column1', 'other_data',), ('column2', 'other_data'), ('column3', 'other_data')]
+        query_results.records = [
+            ('data1', 'data2', 'data3'),
+            ('data4', 'data5', 'data6'),
+            ('data7', 'data8', 'data9')
+        ]
+        formatted_result = utils.format_query_result(query_results)
+
+        assert formatted_result == [
+            {'column1':'data1', 'column2':'data2', 'column3':'data3'},
+            {'column1':'data4', 'column2':'data5', 'column3':'data6'},
+            {'column1':'data7', 'column2':'data8', 'column3':'data9'}
+        ]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -50,3 +50,32 @@ class TestUtils(object):
             {'column1':'data4', 'column2':'data5', 'column3':'data6'},
             {'column1':'data7', 'column2':'data8', 'column3':'data9'}
         ]
+
+    def test_check_hana_range(self):
+
+        assert utils.check_hana_range('1.0.0.0', ['1.0.0.1']) == False
+        assert utils.check_hana_range('1.0.0.0', ['1.0.0']) == True
+        assert utils.check_hana_range('1.0.0.0', ['1.0.0']) == True
+        assert utils.check_hana_range('1.0.0.1', ['1.0.0.0']) == True
+
+        assert utils.check_hana_range('1.0.0.0', ['1.0.0.1', '2.0.0']) == False
+        assert utils.check_hana_range('2.0.1.0', ['1.0.0.1', '2.0.0.0']) == False
+        assert utils.check_hana_range('1.0.0.0', ['1.0.1.0', '2.0.0.0']) == False
+        assert utils.check_hana_range('1.0.1.0', ['1.0.1.1', '2.0.0.0']) == False
+        assert utils.check_hana_range('1.0.0.1', ['1.0.1', '2.0.0.0']) == False
+
+        assert utils.check_hana_range('1.0.0.0', ['1.0.0', '2.0.0']) == True
+        assert utils.check_hana_range('1.0.1', ['1.0.0.1', '2.0.0']) == True
+        assert utils.check_hana_range('1.0.1', ['1.0.0.0', '2.0.0']) == True
+        assert utils.check_hana_range('2.0.0.0', ['1.0.0.1', '2.0.0.0']) == True
+        assert utils.check_hana_range('1.0.0.1', ['1.0.0', '2.0.0.0']) == True
+
+        with pytest.raises(ValueError) as err:
+            utils.check_hana_range('1.0.0.0', [])
+
+        assert 'provided availability range does not have the correct number of elements' in str(err.value)
+
+        with pytest.raises(ValueError) as err:
+            utils.check_hana_range('1.0.0.0', ['1.0.0.0', '2.0.0.0', '3.0.0.0'])
+
+        assert 'provided availability range does not have the correct number of elements' in str(err.value)


### PR DESCRIPTION
Add option to disable queries depending on the HANA db version.

I have changed and moved some methods to other files (format_query_result creates a list of dictionaries, instead of a list of tuples) and redo the _manage_gauge method to use a dictionary instead of tuples and check the correct order of the labels (right now, it depended on the query itself matched with labels order).