### PR TITLE
Add metadata labels to the metrics

### DIFF
--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 24 03:00:45 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.4.1 Add new metadata labels to the metrics (sid, instance
+number and databse name) 
+
+-------------------------------------------------------------------
 Wed Oct 23 10:53:36 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.4.0 Remove the factory usage to gain simplicity as only 

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -26,7 +26,7 @@
 %endif
 
 Name:           hanadb_exporter
-Version:        0.4.0
+Version:        0.4.1
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -120,11 +120,8 @@ def run():
     except KeyError as err:
         raise KeyError('Configuration file {} is malformed: {} not found'.format(args.config, err))
 
-    hana_version = prometheus_exporter.SapHanaCollector.get_hana_version(connector)
-    LOGGER.info('SAP HANA database version: %s', hana_version)
-
-    collector = prometheus_exporter.SapHanaCollector(
-        connector=connector, metrics_file=metrics, hana_version=hana_version)
+    collector = prometheus_exporter.SapHanaCollector(connector=connector, metrics_file=metrics)
+    collector.retrieve_metadata()
 
     REGISTRY.register(collector)
     LOGGER.info('exporter sucessfully registered')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -190,9 +190,11 @@ class TestMain(object):
         mock_setup_loggin.assert_called_once_with(config)
         mock_hdb.assert_called_once_with()
         mock_connect.assert_called_once_with(mock_connector, config)
-        mock_exporter.get_hana_version.assert_called_once_with(mock_connector)
+
         mock_exporter.assert_called_once_with(
-            connector=mock_connector, metrics_file='metrics', hana_version='1.0.0')
+            connector=mock_connector, metrics_file='metrics')
+        mock_collector.retrieve_metadata.assert_called_once_with()
+
         mock_registry.assert_called_once_with(mock_collector)
         mock_logger.info.assert_has_calls([
             mock.call('exporter sucessfully registered'),

--- a/tests/prometheus_exporter_test.py
+++ b/tests/prometheus_exporter_test.py
@@ -42,20 +42,59 @@ class TestSapHanaCollector(object):
         self._mock_metrics_config = mock.Mock()
         mock_metrics.return_value = self._mock_metrics_config
         self._mock_connector = mock.Mock()
-        hana_version = '2.0'
         self._collector = prometheus_exporter.SapHanaCollector(
-            self._mock_connector, 'metrics.json', hana_version)
+            self._mock_connector, 'metrics.json',
+            sid='prd', insnr='00', database_name='db_name', hana_version='2.0')
+
+    @mock.patch('hanadb_exporter.prometheus_metrics.PrometheusMetrics')
+    def test_metadata_labels(self, mock_metrics):
+        self._mock_metrics_config = mock.Mock()
+        mock_metrics.return_value = self._mock_metrics_config
+        self._collector = prometheus_exporter.SapHanaCollector(
+            self._mock_connector, 'metrics.json')
+        assert [None, None, None] == self._collector.metadata_labels
+
+        self._collector = prometheus_exporter.SapHanaCollector(
+            self._mock_connector, 'metrics.json',
+            sid='prd', insnr='00', database_name='db_name', hana_version='2.0')
+        assert ['prd', '00', 'db_name'] == self._collector.metadata_labels
 
     @mock.patch('hanadb_exporter.utils.format_query_result')
-    def test_get_hana_version(self, mock_format_query):
-        mock_connector = mock.Mock()
-        mock_connector.query.return_value = 'query_result'
-        mock_format_query.return_value = [{'VERSION': '2.0'}]
-        version = prometheus_exporter.SapHanaCollector.get_hana_version(mock_connector)
+    @mock.patch('logging.Logger.info')
+    def test_retrieve_metadata(self, mock_logger, mock_format_query):
 
-        mock_connector.query.assert_called_once_with('SELECT * FROM sys.m_database;')
-        mock_format_query.assert_called_once_with('query_result')
-        assert version == '2.0'
+        mock_result = mock.Mock()
+        self._collector._hdb_connector.query = mock.Mock(return_value=mock_result)
+        mock_format_query.return_value = [
+            {'SID': 'ha1', 'INSNR': '10', 'DATABASE_NAME': 'DB_SYSTEM', 'VERSION': '1.2.3'}]
+
+        self._collector.retrieve_metadata()
+
+        mock_logger.assert_has_calls([
+            mock.call('Querying database metadata...'),
+            mock.call(
+                'Metadata retrieved. version: %s, sid: %s, insnr: %s, database: %s',
+                '1.2.3', 'ha1', '10', 'DB_SYSTEM')
+        ])
+        self._collector._hdb_connector.query.assert_called_once_with(
+"""SELECT
+(SELECT value
+FROM M_SYSTEM_OVERVIEW
+WHERE section = 'System'
+AND name = 'Instance ID') SID,
+(SELECT value
+FROM M_SYSTEM_OVERVIEW
+WHERE section = 'System'
+AND name = 'Instance Number') INSNR,
+m.database_name,
+m.version
+FROM m_database m;"""
+        )
+        mock_format_query.assert_called_once_with(mock_result)
+        assert self._collector.sid == 'ha1'
+        assert self._collector.insnr == '10'
+        assert self._collector.database_name == 'DB_SYSTEM'
+        assert self._collector.hana_version == '1.2.3'
 
     @mock.patch('hanadb_exporter.prometheus_exporter.core')
     @mock.patch('logging.Logger.debug')
@@ -82,12 +121,13 @@ class TestSapHanaCollector(object):
         metric_obj = self._collector._manage_gauge(mock_metric, formatted_query)
 
         mock_core.GaugeMetricFamily.assert_called_once_with(
-            'name', 'description', None, ['column1', 'column2'], 'mb')
+            'name', 'description', None,
+            ['sid', 'insnr', 'database_name', 'column1', 'column2'], 'mb')
 
         mock_gauge_instance.add_metric.assert_has_calls([
-            mock.call(['data1', 'data2'], 'data3'),
-            mock.call(['data4', 'data5'], 'data6'),
-            mock.call(['data7', 'data8'], 'data9')
+            mock.call(['prd', '00', 'db_name', 'data1', 'data2'], 'data3'),
+            mock.call(['prd', '00', 'db_name', 'data4', 'data5'], 'data6'),
+            mock.call(['prd', '00', 'db_name', 'data7', 'data8'], 'data9')
         ])
 
         mock_logger.assert_called_once_with('%s \n', 'samples')
@@ -95,7 +135,7 @@ class TestSapHanaCollector(object):
 
     @mock.patch('hanadb_exporter.prometheus_exporter.core')
     @mock.patch('logging.Logger.error')
-    def test_incorrect_label(self, mock_logger, mock_core):
+    def test_manage_gauge_incorrect_label(self, mock_logger, mock_core):
 
         mock_gauge_instance = mock.Mock()
         mock_core.GaugeMetricFamily = mock.Mock()
@@ -117,13 +157,17 @@ class TestSapHanaCollector(object):
         with pytest.raises(ValueError) as err:
             metric_obj = self._collector._manage_gauge(mock_metric, formatted_query)
 
-            assert('One or more label(s) specified in metrics.json'
-                   ' for metric: "{}" is not found in the the query result'.format(
-                    'name') in str(err.value))
+        mock_core.GaugeMetricFamily.assert_called_once_with(
+            'name', 'description', None,
+            ['sid', 'insnr', 'database_name', 'column4', 'column5'], 'mb')
+
+        assert('One or more label(s) specified in metrics.json'
+               ' for metric: "{}" is not found in the the query result'.format(
+                'name') in str(err.value))
 
     @mock.patch('hanadb_exporter.prometheus_exporter.core')
     @mock.patch('logging.Logger.error')
-    def test_incorrect_value(self, mock_logger, mock_core):
+    def test_manage_gauge_incorrect_value(self, mock_logger, mock_core):
 
         mock_gauge_instance = mock.Mock()
         mock_gauge_instance.samples = 'samples'
@@ -146,6 +190,10 @@ class TestSapHanaCollector(object):
         with pytest.raises(ValueError) as err:
             metric_obj = self._collector._manage_gauge(mock_metric, formatted_query)
 
+        mock_core.GaugeMetricFamily.assert_called_once_with(
+            'name', 'description', None,
+            ['sid', 'insnr', 'database_name', 'column1', 'column2'], 'mb')
+
         assert('Specified value in metrics.json for metric'
                ' "{}": ({}) not found in the query result'.format(
                 'name', 'column4') in str(err.value))
@@ -153,7 +201,7 @@ class TestSapHanaCollector(object):
     @mock.patch('hanadb_exporter.utils.format_query_result')
     @mock.patch('hanadb_exporter.utils.check_hana_range')
     @mock.patch('logging.Logger.error')
-    def test_value_error(self, mock_logger, mock_hana_range, mock_format_query):
+    def test_collect_value_error(self, mock_logger, mock_hana_range, mock_format_query):
         """
         Test that when _manage_gauge is called and return ValueError (labels or value)
         are incorrect, that the ValueError is catched by collect() and a error is raised
@@ -314,7 +362,7 @@ class TestSapHanaCollector(object):
     @mock.patch('hanadb_exporter.utils.check_hana_range')
     @mock.patch('hanadb_exporter.prometheus_exporter.hdb_connector.connectors.base_connector')
     @mock.patch('logging.Logger.error')
-    def test_incorrect_query(self, mock_logger, mock_base_connector, mock_hana_range):
+    def test_collect_incorrect_query(self, mock_logger, mock_base_connector, mock_hana_range):
 
         self._collector._hdb_connector.reconnect = mock.Mock()
         mock_base_connector.QueryError = Exception


### PR DESCRIPTION
New metadata labels added to the metrics. Now, sid, instance number and database name are always exported with names `sid`, `insnr` and `database_name`.

Some technical topics that would be good to discuss:

- I have given the option to set customs values for this metrics in the `__init__`. This has the advantage that we can customize the metrics, but in the other hand we can export labels that don't match with the database information.
- If `retrieve_metadata` is executed the current labels will be exported always.
- I don't do any kind of sanity check. The code requires to add the metadata manually or run the `retrieve_metadata` method before registering the collector.

So, the question. Should be run `retrieve_metadata` in the `__init__` and always use the exact values? I don't really like to add actions in the the `__init__` but this would avoid incorrect metrics for sure. Besides, the method call after the init wouldn't be needed. In that case, we would convert the variables to protected and wouldn't be i[dated by the user.

Opinions?

*INFO: Metadata labels will be added always! We could customize this addition as well in the future*