### PR TITLE
Feature/multitenant exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@
 Prometheus exporter written in Python, to export SAP HANA database metrics. The
 project is based in the official prometheus exporter: [prometheus_client](https://github.com/prometheus/client_python).
 
+The exporter is able to export the metrics from more than 1 database/tenant if the `multi_tenant` option is enabled in the configuration file (enabled by default).
+
+The labels `sid` (system identifier), `insnr` (instance number), `database_name` (database name) and `host` (machine hostname) will be exported for all the metrics.
+
 
 ## Prerequisites
 
-1. A running and reachable SAP HANA database. Running the exporter in the
+1. A running and reachable SAP HANA database (single or multi container). Running the exporter in the
 same machine where the HANA database is running is recommended. Ideally each database
 should be monitored by one exporter.
 
@@ -53,6 +57,8 @@ zypper in python3-PyHDB
 An example of `config.json` available in [config.json.example](config.json.example). Here the most
 important items in the configuration file:
   - `exposition_port`: Port where the prometheus exporter will be exposed (8001 by default).
+  - `multi_tenant`: Export the metrics from other tenants. To use this the connection must be done with the System Database (port 30013).
+  - `timeout`: Timeout to connect to the database. After this time the app will fail (even in daemon mode).
   - `hana.host`: Address of the SAP HANA database.
   - `hana.port`: Port where the SAP HANA database is exposed.
   - `hana.user`: An existing user with access right to the SAP HANA database.

--- a/config.json.example
+++ b/config.json.example
@@ -1,8 +1,10 @@
 {
   "exposition_port": 8001,
+  "multi_tenant": true,
+  "timeout": 600,
   "hana": {
     "host": "localhost",
-    "port": 30015,
+    "port": 30013,
     "user": "SYSTEM",
     "password": "PASSWORD"
   },

--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct 25 06:14:03 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.5.0 Add the option to export metrics from multiple
+databases/tenants 
+
+-------------------------------------------------------------------
 Thu Oct 24 03:00:45 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.4.1 Add new metadata labels to the metrics (sid, instance

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -26,7 +26,7 @@
 %endif
 
 Name:           hanadb_exporter
-Version:        0.4.1
+Version:        0.5.0
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -1,0 +1,94 @@
+"""
+SAP HANA database manager
+
+:author: xarbulu
+:organization: SUSE Linux GmbH
+:contact: xarbulu@suse.de
+
+:since: 2019-10-24
+"""
+
+import logging
+import time
+
+from shaptools import hdb_connector
+from hanadb_exporter import utils
+
+RECONNECTION_INTERVAL = 15
+
+
+class DatabaseManager(object):
+    """
+    Manage the connection to a multi container HANA system
+    """
+
+    TENANT_DATA_QUERY =\
+"""SELECT SQL_PORT FROM SYS_DATABASES.M_SERVICES
+WHERE (SERVICE_NAME='indexserver' and COORDINATOR_TYPE= 'MASTER')"""
+
+    def __init__(self):
+        self._logger = logging.getLogger(__name__)
+        self._system_db_connector = hdb_connector.HdbConnector()
+        self._db_connectors = []
+
+    def _get_tenants_port(self):
+        """
+        Get tenants port
+        """
+        data = self._system_db_connector.query(self.TENANT_DATA_QUERY)
+        formatted_data = utils.format_query_result(data)
+        for tenant_data in formatted_data:
+            yield int(tenant_data['SQL_PORT'])
+
+    def _connect_tenants(self, host, user, password):
+        """
+        Connect to the tenants
+
+        Args:
+            host (str): Host of the HANA database
+            user (str): System database user name (SYSTEM usually)
+            password (str): System database user password
+        """
+        for tenant_port in self._get_tenants_port():
+            conn = hdb_connector.HdbConnector()
+            conn.connect(
+                host, tenant_port, user=user, password=password, RECONNECT='FALSE')
+            self._db_connectors.append(conn)
+
+    def start(self, host, port, user, password, multi_tenant=True, timeout=600):
+        """
+        Start de database manager. This will open a connection with the System database and
+        retrieve the current environemtn tenant databases data
+
+        Args:
+            host (str): Host of the HANA database
+            port (int): Port of the System database (3XX13 when XX is the instance number)
+            user (str): System database user name (SYSTEM usually)
+            password (str): System database user password
+            multi_tenant (bool): Connect to all tenants checking the data in the System database
+            timeout (int, opt): Timeout in seconds to connect to the System database
+        """
+        current_time = time.time()
+        timeout = current_time + timeout
+        while current_time <= timeout:
+            try:
+                self._system_db_connector.connect(
+                    host, port, user=user, password=password, RECONNECT='FALSE')
+                self._db_connectors.append(self._system_db_connector)
+                break
+            except hdb_connector.connectors.base_connector.ConnectionError as err:
+                self._logger.error(
+                    'the connection to the system database failed. error message: %s', str(err))
+                time.sleep(RECONNECTION_INTERVAL)
+                current_time = time.time()
+        else:
+            raise hdb_connector.ConnectionError('timeout reached connecting the System database')
+
+        if multi_tenant:
+            self._connect_tenants(host, user, password)
+
+    def get_connectors(self):
+        """
+        Get the connectors
+        """
+        return self._db_connectors

--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -82,7 +82,8 @@ WHERE (SERVICE_NAME='indexserver' and COORDINATOR_TYPE= 'MASTER')"""
                 time.sleep(RECONNECTION_INTERVAL)
                 current_time = time.time()
         else:
-            raise hdb_connector.ConnectionError('timeout reached connecting the System database')
+            raise hdb_connector.connectors.base_connector.ConnectionError(
+                'timeout reached connecting the System database')
 
         if multi_tenant:
             self._connect_tenants(host, user, password)

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -1,0 +1,193 @@
+"""
+Unitary tests for exporters/db_manager.py.
+
+:author: xarbulu
+:organization: SUSE Linux GmbH
+:contact: xarbulu@suse.com
+
+:since: 2019-10-25
+"""
+
+# pylint:disable=C0103,C0111,W0212,W0611
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+sys.modules['shaptools'] = mock.MagicMock()
+from hanadb_exporter import db_manager
+
+
+class TestDatabaseManager(object):
+    """
+    Unitary tests for hanadb_exporter/db_manager.py.
+    """
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector.HdbConnector')
+    def setup(self, mock_hdb):
+        """
+        Test setUp.
+        """
+
+        self._db_manager = db_manager.DatabaseManager()
+        mock_hdb.assert_called_once_with()
+
+    @mock.patch('hanadb_exporter.db_manager.utils.format_query_result')
+    def test_get_tenants_port(self, mock_format_query):
+        self._db_manager._system_db_connector = mock.Mock()
+        self._db_manager._system_db_connector.query.return_value = 'result'
+        ports = ['30040', '30041']
+        mock_format_query.return_value = [{'SQL_PORT': ports[0]}, {'SQL_PORT': ports[1]}]
+
+        for i, port in enumerate(self._db_manager._get_tenants_port()):
+            assert port == int(ports[i])
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector.HdbConnector')
+    def test_connect_tenants(self, mock_hdb):
+
+        self._db_manager._get_tenants_port = mock.Mock(return_value=[1, 2, 3])
+
+        mock_conn1 = mock.Mock()
+        mock_conn2 = mock.Mock()
+        mock_conn3 = mock.Mock()
+
+        mock_hdb.side_effect = [mock_conn1, mock_conn2, mock_conn3]
+
+        self._db_manager._connect_tenants('10.10.10.10', 'SYSTEM', 'pass')
+
+        assert mock_hdb.call_count == 3
+
+        mock_conn1.connect.assert_called_once_with(
+            '10.10.10.10', 1, user='SYSTEM', password='pass', RECONNECT='FALSE')
+        mock_conn2.connect.assert_called_once_with(
+            '10.10.10.10', 2, user='SYSTEM', password='pass', RECONNECT='FALSE')
+        mock_conn3.connect.assert_called_once_with(
+            '10.10.10.10', 3, user='SYSTEM', password='pass', RECONNECT='FALSE')
+
+        assert self._db_manager._db_connectors == [mock_conn1, mock_conn2, mock_conn3]
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
+    @mock.patch('logging.Logger.error')
+    @mock.patch('time.sleep')
+    @mock.patch('time.time')
+    def test_start_timeout(self, mock_time, mock_sleep, mock_logger, mock_exception):
+        mock_exception.ConnectionError = Exception
+        mock_time.side_effect = [0, 1, 2, 3]
+        self._db_manager._system_db_connector = mock.Mock()
+
+        self._db_manager._system_db_connector.connect.side_effect = [
+            mock_exception.ConnectionError('err'),
+            mock_exception.ConnectionError('err'),
+            mock_exception.ConnectionError('err')]
+
+        with pytest.raises(mock_exception.ConnectionError) as err:
+            self._db_manager.start(
+                '10.10.10.10', 30013, 'user', 'pass', multi_tenant=False, timeout=2)
+
+        assert 'timeout reached connecting the System database' in str(err.value)
+
+        self._db_manager._system_db_connector.connect.assert_has_calls([
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE')
+        ])
+
+        mock_sleep.assert_has_calls([
+            mock.call(15),
+            mock.call(15),
+            mock.call(15)
+        ])
+
+        mock_logger.assert_has_calls([
+            mock.call('the connection to the system database failed. error message: %s', 'err'),
+            mock.call('the connection to the system database failed. error message: %s', 'err'),
+            mock.call('the connection to the system database failed. error message: %s', 'err')
+        ])
+
+        assert self._db_manager._db_connectors == []
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
+    @mock.patch('logging.Logger.error')
+    @mock.patch('time.sleep')
+    @mock.patch('time.time')
+    def test_start_correct(self, mock_time, mock_sleep, mock_logger, mock_exception):
+        mock_exception.ConnectionError = Exception
+        mock_time.side_effect = [0, 1, 2, 3]
+        self._db_manager._system_db_connector = mock.Mock()
+        self._db_manager._connect_tenants = mock.Mock()
+
+        self._db_manager._system_db_connector.connect.side_effect = [
+            mock_exception.ConnectionError('err'),
+            mock_exception.ConnectionError('err'),
+            None]
+
+        self._db_manager.start(
+            '10.10.10.10', 30013, 'user', 'pass', multi_tenant=False, timeout=2)
+
+        self._db_manager._system_db_connector.connect.assert_has_calls([
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE')
+        ])
+
+        mock_sleep.assert_has_calls([
+            mock.call(15),
+            mock.call(15)
+        ])
+
+        mock_logger.assert_has_calls([
+            mock.call('the connection to the system database failed. error message: %s', 'err'),
+            mock.call('the connection to the system database failed. error message: %s', 'err')
+        ])
+
+        assert self._db_manager._db_connectors == [self._db_manager._system_db_connector]
+        self._db_manager._connect_tenants.assert_not_called()
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
+    @mock.patch('logging.Logger.error')
+    @mock.patch('time.sleep')
+    @mock.patch('time.time')
+    def test_start_correct_multitenant(self, mock_time, mock_sleep, mock_logger, mock_exception):
+        mock_exception.ConnectionError = Exception
+        mock_time.side_effect = [0, 1, 2, 3]
+        self._db_manager._system_db_connector = mock.Mock()
+        self._db_manager._connect_tenants = mock.Mock()
+
+        self._db_manager._system_db_connector.connect.side_effect = [
+            mock_exception.ConnectionError('err'),
+            mock_exception.ConnectionError('err'),
+            None]
+
+        self._db_manager.start(
+            '10.10.10.10', 30013, 'user', 'pass', multi_tenant=True, timeout=2)
+
+        self._db_manager._system_db_connector.connect.assert_has_calls([
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
+            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE')
+        ])
+
+        mock_sleep.assert_has_calls([
+            mock.call(15),
+            mock.call(15)
+        ])
+
+        mock_logger.assert_has_calls([
+            mock.call('the connection to the system database failed. error message: %s', 'err'),
+            mock.call('the connection to the system database failed. error message: %s', 'err')
+        ])
+
+        assert self._db_manager._db_connectors == [self._db_manager._system_db_connector]
+        self._db_manager._connect_tenants.assert_called_once_with('10.10.10.10', 'user', 'pass')
+
+
+    def test_get_connectors(self):
+        self._db_manager._db_connectors = 'conns'
+        assert 'conns' == self._db_manager.get_connectors()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -89,83 +89,30 @@ class TestMain(object):
         ])
 
     @mock.patch('hanadb_exporter.main.LOGGER')
-    def test_connect(self, mock_logger):
-
-        mock_connector = mock.Mock()
-        config = {
-            'hana': {
-                'host': '123.123.123.123',
-                'port': 1234,
-                'user': 'user',
-                'password': 'pass'
-            }
-        }
-
-        main.connect(mock_connector, config)
-
-        mock_logger.info.assert_called_once_with(
-            'connecting to the hana database (%s:%s)', '123.123.123.123', 1234)
-        mock_connector.connect.assert_called_once_with(
-            '123.123.123.123', 1234, user='user', password='pass', RECONNECT='FALSE')
-
-    @mock.patch('hanadb_exporter.main.LOGGER')
-    @mock.patch('hanadb_exporter.main.hdb_connector.connectors.base_connector')
-    @mock.patch('time.sleep')
-    def test_connect_loop(self, mock_sleep, mock_connection_error, mock_logger):
-
-        mock_exception = Exception
-        mock_connection_error.ConnectionError = mock_exception
-        mock_connector = mock.Mock()
-        config = {
-            'hana': {
-                'host': '123.123.123.123',
-                'user': 'user',
-                'password': 'pass'
-            }
-        }
-
-        mock_connector.connect.side_effect = [mock_exception('err1'), mock_exception('err2'), True]
-
-        main.connect(mock_connector, config)
-
-        mock_logger.info.assert_called_once_with(
-            'connecting to the hana database (%s:%s)', '123.123.123.123', 30015)
-        mock_connector.connect.assert_has_calls([
-            mock.call('123.123.123.123', 30015, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('123.123.123.123', 30015, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('123.123.123.123', 30015, user='user', password='pass', RECONNECT='FALSE')
-        ])
-
-        mock_logger.error.assert_has_calls([
-            mock.call('the connection to the database failed. error message: %s', 'err1'),
-            mock.call('the connection to the database failed. error message: %s', 'err2')
-        ])
-
-        mock_sleep.assert_has_calls([
-            mock.call(15),
-            mock.call(15)
-        ])
-
-    @mock.patch('hanadb_exporter.main.LOGGER')
-    @mock.patch('hanadb_exporter.main.connect')
     @mock.patch('hanadb_exporter.main.parse_arguments')
     @mock.patch('hanadb_exporter.main.parse_config')
     @mock.patch('hanadb_exporter.main.setup_logging')
-    @mock.patch('hanadb_exporter.main.hdb_connector.HdbConnector')
-    @mock.patch('hanadb_exporter.main.prometheus_exporter.SapHanaCollector')
+    @mock.patch('hanadb_exporter.main.db_manager.DatabaseManager')
+    @mock.patch('hanadb_exporter.main.prometheus_exporter.SapHanaCollectors')
     @mock.patch('hanadb_exporter.main.REGISTRY.register')
     @mock.patch('hanadb_exporter.main.start_http_server')
     @mock.patch('logging.getLogger')
     @mock.patch('time.sleep')
     def test_run(
             self, mock_sleep, mock_get_logger, mock_start_server, mock_registry,
-            mock_exporter, mock_hdb, mock_setup_loggin,
-            mock_parse_config, mock_parse_arguments, mock_connect, mock_logger):
+            mock_exporters, mock_db_manager, mock_setup_logging,
+            mock_parse_config, mock_parse_arguments, mock_logger):
 
         mock_arguments = mock.Mock(config='config', metrics='metrics')
         mock_parse_arguments.return_value = mock_arguments
 
         config = {
+            'hana': {
+                'host': '10.10.10.10',
+                'port': 1234,
+                'user': 'user',
+                'password': 'pass'
+            },
             'logging': {
                 'log_file': 'my_file',
                 'config_file': 'my_config_file'
@@ -173,12 +120,12 @@ class TestMain(object):
         }
         mock_parse_config.return_value = config
 
-        mock_connector = mock.Mock()
-        mock_hdb.return_value = mock_connector
+        db_instance = mock.Mock()
+        db_instance.get_connectors.return_value = 'connectors'
+        mock_db_manager.return_value = db_instance
 
         mock_collector = mock.Mock()
-        mock_exporter.return_value = mock_collector
-        mock_exporter.get_hana_version.return_value = '1.0.0'
+        mock_exporters.return_value = mock_collector
 
         mock_sleep.side_effect = Exception
 
@@ -187,13 +134,13 @@ class TestMain(object):
 
         mock_parse_arguments.assert_called_once_with()
         mock_parse_config.assert_called_once_with(mock_arguments.config)
-        mock_setup_loggin.assert_called_once_with(config)
-        mock_hdb.assert_called_once_with()
-        mock_connect.assert_called_once_with(mock_connector, config)
-
-        mock_exporter.assert_called_once_with(
-            connector=mock_connector, metrics_file='metrics')
-        mock_collector.retrieve_metadata.assert_called_once_with()
+        mock_setup_logging.assert_called_once_with(config)
+        mock_db_manager.assert_called_once_with()
+        db_instance.start.assert_called_once_with(
+            '10.10.10.10', 1234, 'user', 'pass', multi_tenant=True, timeout=600)
+        db_instance.get_connectors.assert_called_once_with()
+        mock_exporters.assert_called_once_with(
+            connectors='connectors', metrics_file='metrics')
 
         mock_registry.assert_called_once_with(mock_collector)
         mock_logger.info.assert_has_calls([
@@ -204,31 +151,26 @@ class TestMain(object):
         mock_sleep.assert_called_once_with(1)
 
     @mock.patch('hanadb_exporter.main.LOGGER')
-    @mock.patch('hanadb_exporter.main.connect')
     @mock.patch('hanadb_exporter.main.parse_arguments')
     @mock.patch('hanadb_exporter.main.parse_config')
-    @mock.patch('hanadb_exporter.main.hdb_connector.HdbConnector')
+    @mock.patch('hanadb_exporter.main.db_manager.DatabaseManager')
     @mock.patch('logging.getLogger')
     @mock.patch('logging.basicConfig')
     def test_run_malformed(
-            self, mock_logging, mock_get_logger, mock_hdb,
-            mock_parse_config, mock_parse_arguments, mock_connect, mock_logger):
+            self, mock_logging, mock_get_logger, mock_db_manager,
+            mock_parse_config, mock_parse_arguments, mock_logger):
 
         mock_arguments = mock.Mock(config='config', metrics='metrics', verbosity='DEBUG')
         mock_parse_arguments.return_value = mock_arguments
 
         config = {
             'hana': {
-                'host': '123.123.123.123',
                 'port': 1234,
                 'user': 'user',
                 'password': 'pass'
             }
         }
         mock_parse_config.return_value = config
-        mock_connect.side_effect = KeyError('error')
-        hdb_instance = mock.Mock()
-        mock_hdb.return_value = hdb_instance
 
         with pytest.raises(KeyError) as err:
             main.run()
@@ -236,7 +178,6 @@ class TestMain(object):
         mock_parse_arguments.assert_called_once_with()
         mock_parse_config.assert_called_once_with(mock_arguments.config)
         mock_logging.assert_called_once_with(level='DEBUG')
-        mock_hdb.assert_called_once_with()
-        mock_connect.assert_called_once_with(hdb_instance, config)
+        mock_db_manager.assert_called_once_with()
         assert 'Configuration file {} is malformed: {} not found'.format(
-            'config', '\'error\'') in str(err.value)
+            'config', '\'host\'') in str(err.value)


### PR DESCRIPTION
This PR implements the multiple tenant monitoring finding them automatically.

It provides the option to enable multi tenant passing the system database port or just single tenant using the `multi_tenant: false` option in the configuration file.

This PR is just a RFC, so let's talk about the utility of this logic.

The other option is just to let the code as it is, and start several daemons with the sql port of each database.

The result will be exactly the same for prometheus regarding the metrics (except you need to change the prometheus configuration to scrape from all the exporters)

**INFO: Forget the 1st commit, it's the same than the other PR: https://github.com/SUSE/hanadb_exporter/pull/44**