### PR TITLE
Feature/add userkey option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ zypper ref
 zypper in python3-PyHDB
 ```
 
-## Configuring and running the exporter
+## Configuring the exporter
 
-1. Create the `config.json` configuration file.
+Create the `config.json` configuration file.
 An example of `config.json` available in [config.json.example](config.json.example). Here the most
 important items in the configuration file:
   - `exposition_port`: Port where the prometheus exporter will be exposed (8001 by default).
@@ -99,14 +99,16 @@ GRANT HANADB_EXPORTER_ROLE TO HANADB_EXPORTER_USER;
 ```
 
 
-2. Start the exporter by running the following command:
+## Running the exporter
+
+Start the exporter by running the following command:
 ```
 hanadb_exporter -c config.json -m metrics.json
 # Or
 python3 hanadb_exporter/main.py -c config.json -m metrics.json
 ```
 
-## Running as a daemon
+### Running as a daemon
 The hanadb_exporter can be executed using `systemd`. For that, the best option is to install the
 project using a rpm package. This can be done following the next steps (this example is for tumbleweed):
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ important items in the configuration file:
   - `timeout`: Timeout to connect to the database. After this time the app will fail (even in daemon mode).
   - `hana.host`: Address of the SAP HANA database.
   - `hana.port`: Port where the SAP HANA database is exposed.
+  - `hana.userkey`: Stored user key. This is the secure option if you don't want to have the password in the configuration file. The `userkey` and `user/password` are self exclusive.
   - `hana.user`: An existing user with access right to the SAP HANA database.
   - `hana.password`: Password of an existing user.
   - `logging.config_file`: Python logging system configuration file (by default WARN and ERROR level messages will be sent to the syslog)
@@ -69,6 +70,17 @@ important items in the configuration file:
 The logging configuration file follows the python standard logging system style: [Python logging](https://docs.python.org/3/library/logging.config.html).
 
 Using the default [configuration file](./logging_config.ini), it will redirect the logs to the file assigned in the [json configuration file](./config.json.example) and to the syslog (only logging level up to WARNING).
+
+### Using the stored user key
+
+To use the `userkey` option the `dbapi` must be installed (usually stored in `/hana/shared/PRD/hdbclient/hdbcli-N.N.N.tar.gz`).
+It cannot be used from other different client (the key is stored in the client itself). This will raise the `hdbcli.dbapi.Error: (-10104, 'Invalid value for KEY')` error.
+For that a new stored user key must be created with the user that is running python. For that (please, notice that the `hdbclient` is the same as the `dbapi` python package):
+```
+/hana/shared/PRD/hdbclient/hdbuserstore set yourkey host:30013@SYSTEMDB SYSTEM pass
+```
+**Don't use the stored user key created for the backup as this is create using the sidadm user.**
+**The usage of a user with access only to the monitoring tables is recommended instead of using SYSTEM user.**
 
 2. Start the exporter by running the following command:
 ```

--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec  9 08:21:18 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.5.2 Add the option to use the hanadb_exporter with
+the stored user key. This gives the option to avoid the plain
+user/password strings usage. 
+
+-------------------------------------------------------------------
 Wed Nov 6 12:48:03 UTC 2019 - Diego Akechi <dakechi@suse.com>
 
 - Version 0.5.1 Add the SAP HANA current alerts rating metric.

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -26,7 +26,7 @@
 %endif
 
 Name:           hanadb_exporter
-Version:        0.5.1
+Version:        0.5.2
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.2"

--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -98,11 +98,14 @@ WHERE (SERVICE_NAME='indexserver' and COORDINATOR_TYPE= 'MASTER')"""
             timeout (int, opt): Timeout in seconds to connect to the System database
         """
         connection_data = self._get_connection_data(
-            kwargs.get('userkey'), kwargs.get('user'), kwargs.get('password'))
+            kwargs.get('userkey', None), kwargs.get('user', ''), kwargs.get('password', ''))
         current_time = time.time()
         timeout = current_time + kwargs.get('timeout', 600)
         while current_time <= timeout:
             try:
+                # parameters are passed using kwargs to the connect method
+                # pyhdb only uses 'user' and `password`
+                # dbapi uses 'user', 'password', 'userkey' and other optional params
                 self._system_db_connector.connect(host, port, **connection_data)
                 self._db_connectors.append(self._system_db_connector)
                 break

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -92,7 +92,9 @@ def run():
         dbs = db_manager.DatabaseManager()
         dbs.start(
             hana_config['host'], hana_config.get('port', 30013),
-            hana_config['user'], hana_config['password'],
+            user=hana_config.get('user', ''),
+            password=hana_config.get('password', ''),
+            userkey=hana_config.get('userkey', None),
             multi_tenant=config.get('multi_tenant', True),
             timeout=config.get('timeout', 600))
     except KeyError as err:

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -60,24 +60,92 @@ class TestDatabaseManager(object):
 
         mock_hdb.side_effect = [mock_conn1, mock_conn2, mock_conn3]
 
-        self._db_manager._connect_tenants('10.10.10.10', 'SYSTEM', 'pass')
+        connection_data = {'mock_data': 'data'}
+
+        self._db_manager._connect_tenants('10.10.10.10', connection_data)
 
         assert mock_hdb.call_count == 3
 
-        mock_conn1.connect.assert_called_once_with(
-            '10.10.10.10', 1, user='SYSTEM', password='pass', RECONNECT='FALSE')
-        mock_conn2.connect.assert_called_once_with(
-            '10.10.10.10', 2, user='SYSTEM', password='pass', RECONNECT='FALSE')
-        mock_conn3.connect.assert_called_once_with(
-            '10.10.10.10', 3, user='SYSTEM', password='pass', RECONNECT='FALSE')
+        mock_conn1.connect.assert_called_once_with('10.10.10.10', 1, **connection_data)
+        mock_conn2.connect.assert_called_once_with('10.10.10.10', 2, **connection_data)
+        mock_conn3.connect.assert_called_once_with('10.10.10.10', 3, **connection_data)
 
         assert self._db_manager._db_connectors == [mock_conn1, mock_conn2, mock_conn3]
+
+    def test_get_connection_data_invalid_data(self):
+
+        with pytest.raises(ValueError) as err:
+            self._db_manager._get_connection_data(None, '', '')
+        assert 'Provided user data is not valid. userkey or user/password pair must be provided' \
+            in str(err.value)
+
+        with pytest.raises(ValueError) as err:
+            self._db_manager._get_connection_data(None, 'user', '')
+        assert 'Provided user data is not valid. userkey or user/password pair must be provided' \
+            in str(err.value)
+
+        with pytest.raises(ValueError) as err:
+            self._db_manager._get_connection_data(None, '', 'pass')
+        assert 'Provided user data is not valid. userkey or user/password pair must be provided' \
+            in str(err.value)
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector')
+    def test_get_connection_data_not_supported(self, mock_api):
+
+        mock_api.API = 'pyhdb'
+        with pytest.raises(db_manager.UserKeyNotSupportedError) as err:
+            self._db_manager._get_connection_data('userkey', '', '')
+        assert 'userkey usage is not supported with pyhdb connector, hdbcli must be installed' \
+            in str(err.value)
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector')
+    @mock.patch('logging.Logger.warn')
+    @mock.patch('logging.Logger.info')
+    def test_get_connection_data_userkey(self, logger,logger_warn, mock_api):
+
+        mock_api.API = 'dbapi'
+        connection_data = self._db_manager._get_connection_data('userkey', '', '')
+        assert connection_data == {
+            'userkey': 'userkey', 'user': '', 'password': '', 'RECONNECT': 'FALSE'}
+        logger.assert_called_once_with(
+            'stored user key %s will be used to connect to the database', 'userkey')
+        assert logger_warn.call_count == 0
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector')
+    @mock.patch('logging.Logger.warn')
+    @mock.patch('logging.Logger.info')
+    def test_get_connection_data_userkey_warn(self, logger,logger_warn, mock_api):
+
+        mock_api.API = 'dbapi'
+        connection_data = self._db_manager._get_connection_data('userkey', 'user', '')
+        assert connection_data == {
+            'userkey': 'userkey', 'user': 'user', 'password': '', 'RECONNECT': 'FALSE'}
+        logger.assert_called_once_with(
+            'stored user key %s will be used to connect to the database', 'userkey')
+        logger_warn.assert_called_once_with(
+            'userkey will be used to create the connection. user/password are omitted')
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector')
+    @mock.patch('logging.Logger.info')
+    def test_get_connection_data_pass(self, logger, mock_api):
+
+        mock_api.API = 'dbapi'
+        connection_data = self._db_manager._get_connection_data(None, 'user', 'pass')
+        assert connection_data == {
+            'userkey': None, 'user': 'user', 'password': 'pass', 'RECONNECT': 'FALSE'}
+        logger.assert_called_once_with(
+            'user/password combination will be used to connect to the databse')
 
     @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
     @mock.patch('logging.Logger.error')
     @mock.patch('time.sleep')
     @mock.patch('time.time')
     def test_start_timeout(self, mock_time, mock_sleep, mock_logger, mock_exception):
+
+        self._db_manager._get_connection_data = mock.Mock()
+        connection_data = {'mock_data': 'data'}
+        self._db_manager._get_connection_data.return_value = connection_data
+
         mock_exception.ConnectionError = Exception
         mock_time.side_effect = [0, 1, 2, 3]
         self._db_manager._system_db_connector = mock.Mock()
@@ -87,16 +155,17 @@ class TestDatabaseManager(object):
             mock_exception.ConnectionError('err'),
             mock_exception.ConnectionError('err')]
 
+        # Method under test
         with pytest.raises(mock_exception.ConnectionError) as err:
             self._db_manager.start(
-                '10.10.10.10', 30013, 'user', 'pass', multi_tenant=False, timeout=2)
+                '10.10.10.10', 30013, user='user', password='pass', multi_tenant=False, timeout=2)
 
         assert 'timeout reached connecting the System database' in str(err.value)
 
         self._db_manager._system_db_connector.connect.assert_has_calls([
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE')
+            mock.call('10.10.10.10', 30013, **connection_data),
+            mock.call('10.10.10.10', 30013, **connection_data),
+            mock.call('10.10.10.10', 30013, **connection_data)
         ])
 
         mock_sleep.assert_has_calls([
@@ -115,9 +184,47 @@ class TestDatabaseManager(object):
 
     @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
     @mock.patch('logging.Logger.error')
+    @mock.patch('time.time')
+    def test_start_invalid_key(self, mock_time, mock_logger, mock_exception):
+
+        self._db_manager._get_connection_data = mock.Mock()
+        connection_data = {'mock_data': 'data'}
+        self._db_manager._get_connection_data.return_value = connection_data
+
+        mock_exception.ConnectionError = Exception
+        mock_time.side_effect = [0, 1, 2, 3]
+        self._db_manager._system_db_connector = mock.Mock()
+        self._db_manager._connect_tenants = mock.Mock()
+
+        self._db_manager._system_db_connector.connect.side_effect = [
+            mock_exception.ConnectionError('Error: Invalid value for KEY')]
+
+        # Method under test
+        with pytest.raises(mock_exception.ConnectionError) as err:
+            self._db_manager.start(
+                '10.10.10.10', 30013, user='user', password='pass', multi_tenant=False, timeout=2)
+
+        assert 'provided userkey is not valid. Check if dbapi is installed correctly' in str(err.value)
+
+        self._db_manager._system_db_connector.connect.assert_called_once_with(
+            '10.10.10.10', 30013, **connection_data)
+
+        mock_logger.assert_called_once_with(
+            'the connection to the system database failed. error message: %s',
+            'Error: Invalid value for KEY')
+
+        self._db_manager._connect_tenants.assert_not_called()
+
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
+    @mock.patch('logging.Logger.error')
     @mock.patch('time.sleep')
     @mock.patch('time.time')
     def test_start_correct(self, mock_time, mock_sleep, mock_logger, mock_exception):
+
+        self._db_manager._get_connection_data = mock.Mock()
+        connection_data = {'mock_data': 'data'}
+        self._db_manager._get_connection_data.return_value = connection_data
+
         mock_exception.ConnectionError = Exception
         mock_time.side_effect = [0, 1, 2, 3]
         self._db_manager._system_db_connector = mock.Mock()
@@ -129,12 +236,12 @@ class TestDatabaseManager(object):
             None]
 
         self._db_manager.start(
-            '10.10.10.10', 30013, 'user', 'pass', multi_tenant=False, timeout=2)
+            '10.10.10.10', 30013, user='user', password='pass', multi_tenant=False, timeout=2)
 
         self._db_manager._system_db_connector.connect.assert_has_calls([
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE')
+            mock.call('10.10.10.10', 30013, **connection_data),
+            mock.call('10.10.10.10', 30013, **connection_data),
+            mock.call('10.10.10.10', 30013, **connection_data)
         ])
 
         mock_sleep.assert_has_calls([
@@ -155,6 +262,11 @@ class TestDatabaseManager(object):
     @mock.patch('time.sleep')
     @mock.patch('time.time')
     def test_start_correct_multitenant(self, mock_time, mock_sleep, mock_logger, mock_exception):
+
+        self._db_manager._get_connection_data = mock.Mock()
+        connection_data = {'mock_data': 'data'}
+        self._db_manager._get_connection_data.return_value = connection_data
+
         mock_exception.ConnectionError = Exception
         mock_time.side_effect = [0, 1, 2, 3]
         self._db_manager._system_db_connector = mock.Mock()
@@ -166,12 +278,12 @@ class TestDatabaseManager(object):
             None]
 
         self._db_manager.start(
-            '10.10.10.10', 30013, 'user', 'pass', multi_tenant=True, timeout=2)
+            '10.10.10.10', 30013, user='user', password='pass', multi_tenant=True, timeout=2)
 
         self._db_manager._system_db_connector.connect.assert_has_calls([
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE'),
-            mock.call('10.10.10.10', 30013, user='user', password='pass', RECONNECT='FALSE')
+            mock.call('10.10.10.10', 30013, **connection_data),
+            mock.call('10.10.10.10', 30013, **connection_data),
+            mock.call('10.10.10.10', 30013, **connection_data)
         ])
 
         mock_sleep.assert_has_calls([
@@ -185,7 +297,7 @@ class TestDatabaseManager(object):
         ])
 
         assert self._db_manager._db_connectors == [self._db_manager._system_db_connector]
-        self._db_manager._connect_tenants.assert_called_once_with('10.10.10.10', 'user', 'pass')
+        self._db_manager._connect_tenants.assert_called_once_with('10.10.10.10', connection_data)
 
 
     def test_get_connectors(self):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -137,7 +137,8 @@ class TestMain(object):
         mock_setup_logging.assert_called_once_with(config)
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
-            '10.10.10.10', 1234, 'user', 'pass', multi_tenant=True, timeout=600)
+            '10.10.10.10', 1234, user='user', password='pass',
+            userkey=None, multi_tenant=True, timeout=600)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
             connectors='connectors', metrics_file='metrics')


### PR DESCRIPTION
Add `userkey` option.
No changes required in `shaptools`.
The documentation about how to use it added to the `README` file as it's not so trivial.

Address: https://github.com/SUSE/hanadb_exporter/issues/48