### PR TITLE
Update metrics collector to continue in None cases

### DIFF
--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 10 09:17:42 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.5.3 Improve metrics collection if some of the rows
+result is None. Before, if any result was None the result was
+not exported. Now, only metrics with None value are ommitted 
+
+-------------------------------------------------------------------
 Mon Dec  9 08:21:18 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.2 Add the option to use the hanadb_exporter with

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -26,7 +26,7 @@
 %endif
 
 Name:           hanadb_exporter
-Version:        0.5.2
+Version:        0.5.3
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/hanadb_exporter/prometheus_exporter.py
+++ b/hanadb_exporter/prometheus_exporter.py
@@ -111,16 +111,18 @@ FROM m_database m;"""
                     if column_name.lower() == metric.value.lower():
                         metric_value = column_value
             if metric_value is None:
-                raise ValueError(
-                    'Specified value in metrics.json for metric'
-                    ' "{}": ({}) not found in the query result'.format(
-                        metric.name, metric.value))
+                self._logger.warn(
+                    'Specified value in metrics.json for metric "%s": (%s) not found or it is '\
+                    'invalid (None) in the query result',
+                    metric.name, metric.value)
+                continue
             elif len(labels) != len(metric.labels):
                 # Log when a label(s) specified in metrics.json is not found in the query result
-                raise ValueError(
-                    'One or more label(s) specified in metrics.json'
-                    ' for metric: "{}" is not found in the the query result'.format(
-                        metric.name))
+                self._logger.warn(
+                    'One or more label(s) specified in metrics.json '
+                    'for metric "%s" that are not found in the query result',
+                    metric.name)
+                continue
             else:
                 # Add sid, insnr and database_name labels
                 combined_labels = self.metadata_labels + labels


### PR DESCRIPTION
A small improvement to continue creating metrics in the cases where one of the rows returns an invalid value (`None`) what there are more possible rows with valid data.
Right now, if any query entry value was `None` the whole metric was not sent.

It's an extremely rare scenario, but it might happen.

Merge after:
https://github.com/SUSE/hanadb_exporter/pull/49
Pending:
Upgrade `spec` and `changes` file