### PR TITLE
Filter invalid tenants data on multitenant usage

### DIFF
--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 15 11:20:30 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.6.1 Fix use case where TENANT_DATA_QUERY query 
+returns columns with invalid values (0 number)
+
+-------------------------------------------------------------------
 Tue Dec 10 11:18:30 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.6.0 Change configuration files location from /etc

--- a/hanadb_exporter.spec
+++ b/hanadb_exporter.spec
@@ -25,7 +25,7 @@
 %define _sysconfdir %{_prefix}/etc
 
 Name:           hanadb_exporter
-Version:        0.6.0
+Version:        0.6.1
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -44,7 +44,7 @@ WHERE COORDINATOR_TYPE='MASTER'"""
         data = self._system_db_connector.query(self.TENANT_DATA_QUERY)
         formatted_data = utils.format_query_result(data)
         for tenant_data in formatted_data:
-            if tenant_data['DATABASE_NAME'] != 'SYSTEMDB':
+            if tenant_data['DATABASE_NAME'] != 'SYSTEMDB' and int(tenant_data['SQL_PORT']):
                 yield tenant_data['DATABASE_NAME'], int(tenant_data['SQL_PORT'])
 
     def _connect_tenants(self, host, connection_data):

--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -30,7 +30,7 @@ class DatabaseManager(object):
 
     TENANT_DATA_QUERY =\
 """SELECT DATABASE_NAME,SQL_PORT FROM SYS_DATABASES.M_SERVICES
-WHERE COORDINATOR_TYPE='MASTER'"""
+WHERE COORDINATOR_TYPE='MASTER' AND SQL_PORT<>0"""
 
     def __init__(self):
         self._logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ WHERE COORDINATOR_TYPE='MASTER'"""
         data = self._system_db_connector.query(self.TENANT_DATA_QUERY)
         formatted_data = utils.format_query_result(data)
         for tenant_data in formatted_data:
-            if tenant_data['DATABASE_NAME'] != 'SYSTEMDB' and int(tenant_data['SQL_PORT']):
+            if tenant_data['DATABASE_NAME'] != 'SYSTEMDB':
                 yield tenant_data['DATABASE_NAME'], int(tenant_data['SQL_PORT'])
 
     def _connect_tenants(self, host, connection_data):

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -43,16 +43,18 @@ class TestDatabaseManager(object):
     def test_get_tenants_port(self, mock_format_query):
         self._db_manager._system_db_connector = mock.Mock()
         self._db_manager._system_db_connector.query.return_value = 'result'
-        ports = ['30040', '30041']
-        dbs = ['PRD', 'QAS']
+        ports = ['30040', '30041', '0']
+        dbs = ['PRD', 'QAS', 'PRD']
         mock_format_query.return_value = [
             {'DATABASE_NAME': dbs[0], 'SQL_PORT': ports[0]},
             {'DATABASE_NAME': dbs[1], 'SQL_PORT': ports[1]},
+            {'DATABASE_NAME': dbs[2], 'SQL_PORT': ports[2]},
             {'DATABASE_NAME': 'SYSTEMDB', 'SQL_PORT': '30013'}]
 
         for i, data in enumerate(self._db_manager._get_tenants_port()):
             assert data[0] == dbs[i]
             assert data[1] == int(ports[i])
+        assert i == 1 # Check only the ports 30040 and 30041 are yielded
 
     @mock.patch('hanadb_exporter.db_manager.hdb_connector.HdbConnector')
     def test_connect_tenants(self, mock_hdb):

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -43,12 +43,11 @@ class TestDatabaseManager(object):
     def test_get_tenants_port(self, mock_format_query):
         self._db_manager._system_db_connector = mock.Mock()
         self._db_manager._system_db_connector.query.return_value = 'result'
-        ports = ['30040', '30041', '0']
-        dbs = ['PRD', 'QAS', 'PRD']
+        ports = ['30040', '30041']
+        dbs = ['PRD', 'QAS']
         mock_format_query.return_value = [
             {'DATABASE_NAME': dbs[0], 'SQL_PORT': ports[0]},
             {'DATABASE_NAME': dbs[1], 'SQL_PORT': ports[1]},
-            {'DATABASE_NAME': dbs[2], 'SQL_PORT': ports[2]},
             {'DATABASE_NAME': 'SYSTEMDB', 'SQL_PORT': '30013'}]
 
         for i, data in enumerate(self._db_manager._get_tenants_port()):


### PR DESCRIPTION
For some reason the query we use to get the SQL port of the tenants can return some rows with 0 as value.
In order to avoid the usage of these invalid ports this change will omit the connection of these values.

![image](https://user-images.githubusercontent.com/36370954/72502518-cb1a2100-3839-11ea-9769-565ef46d9ae0.png)
