### PR TITLE
Feature/add prometheus prefix

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,5 @@
 {
-  "exposition_port": 9968,
+  "exposition_port": 9668,
   "multi_tenant": true,
   "timeout": 600,
   "hana": {

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -132,7 +132,7 @@ def run():
     LOGGER.info('exporter sucessfully registered')
 
     LOGGER.info('starting to serve metrics')
-    start_http_server(config.get('exposition_port', 9968), '0.0.0.0')
+    start_http_server(config.get('exposition_port', 9668), '0.0.0.0')
     while True:
         time.sleep(1)
 

--- a/prometheus-hanadb_exporter.changes
+++ b/prometheus-hanadb_exporter.changes
@@ -1,77 +1,86 @@
 -------------------------------------------------------------------
+Tue Feb 11 13:31:52 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.7.0 created
+- Rename the rpm package to prometheus-hanadb_exporter to follow
+the prometheus conventions
+- Update the default port from 8001 to 9668
+(jsc#SLE-10545)
+
+-------------------------------------------------------------------
 Wed Jan 15 11:20:30 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
-- Version 0.6.1 Fix use case where TENANT_DATA_QUERY query 
+- Version 0.6.1 Fix use case where TENANT_DATA_QUERY query
 returns columns with invalid values (0 number)
 
 -------------------------------------------------------------------
 Tue Dec 10 11:18:30 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.6.0 Change configuration files location from /etc
-to /usr/etc 
+to /usr/etc
 
 -------------------------------------------------------------------
 Tue Dec 10 09:17:42 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.3 Improve metrics collection if some of the rows
 result is None. Before, if any result was None the result was
-not exported. Now, only metrics with None value are ommitted 
+not exported. Now, only metrics with None value are ommitted
 
 -------------------------------------------------------------------
 Mon Dec  9 08:21:18 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.2 Add the option to use the hanadb_exporter with
 the stored user key. This gives the option to avoid the plain
-user/password strings usage. 
+user/password strings usage.
 
 -------------------------------------------------------------------
 Wed Nov 6 12:48:03 UTC 2019 - Diego Akechi <dakechi@suse.com>
 
 - Version 0.5.1 Add the SAP HANA current alerts rating metric.
 This metric expose the current triggered alerts coming from
-inside the database and the rating (severity) of them. The rating 
+inside the database and the rating (severity) of them. The rating
 is classified between 1 and 5.
 
 -------------------------------------------------------------------
 Fri Oct 25 06:14:03 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.0 Add the option to export metrics from multiple
-databases/tenants 
+databases/tenants
 
 -------------------------------------------------------------------
 Thu Oct 24 03:00:45 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.4.1 Add new metadata labels to the metrics (sid, instance
-number and databse name) 
+number and databse name)
 
 -------------------------------------------------------------------
 Wed Oct 23 10:53:36 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
-- Version 0.4.0 Remove the factory usage to gain simplicity as only 
-the prometheus exporter is used 
+- Version 0.4.0 Remove the factory usage to gain simplicity as only
+the prometheus exporter is used
 
 -------------------------------------------------------------------
 Tue Oct 22 06:57:42 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.4 Add reconnection to the database to avoid issues
-when the hana database is stopped and restarted 
+when the hana database is stopped and restarted
 
 -------------------------------------------------------------------
 Wed Aug  7 14:47:46 UTC 2019 - Ayoub Belarbi <abelarbi@suse.de>
 
 - Version 0.3.3 Better handling of query failures and incorrect labels
-and values 
+and values
 
 -------------------------------------------------------------------
 Tue Jul  9 09:56:38 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Version 0.3.2 adding the option to filter the queries by current
-SAP HANA database version 
+SAP HANA database version
 
 -------------------------------------------------------------------
 Wed Jul  3 07:40:46 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
-- Version 0.3.1 updating how the exporter is executed as a daemon 
+- Version 0.3.1 updating how the exporter is executed as a daemon
 
 -------------------------------------------------------------------
 Tue Jul  2 09:19:00 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
@@ -79,19 +88,19 @@ Tue Jul  2 09:19:00 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 - Version 0.3.0 created
 - Code to manage the metrics updated to have a more generic usage
 - metrics.json file structure updated to add more additional information
-- Documentation created to explain how to create/update the metrics.json 
-file 
+- Documentation created to explain how to create/update the metrics.json
+file
 
 -------------------------------------------------------------------
 Mon Jul  1 11:16:58 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
-- Version 0.2.2 created with a new logging system 
+- Version 0.2.2 created with a new logging system
 
 -------------------------------------------------------------------
 Wed Jun 19 07:54:10 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Version 0.2.1 created
-- Systemd support added to daemonize the execution 
+- Systemd support added to daemonize the execution
 
 -------------------------------------------------------------------
 Thu Jun 13 15:52:08 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
@@ -104,5 +113,4 @@ Thu Jun 13 15:52:08 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 -------------------------------------------------------------------
 Wed Jun 12 14:35:50 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
-- First package version 0.1.0 
-
+- First package version 0.1.0

--- a/prometheus-hanadb_exporter.spec
+++ b/prometheus-hanadb_exporter.spec
@@ -25,11 +25,11 @@
 %define _sysconfdir %{_prefix}/etc
 
 Name:           prometheus-hanadb_exporter
-Version:        0.6.1
+Version:        0.7.0
 Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0
-Group:          Development/Languages/Python
+Group:          System/Monitoring
 Url:            https://github.com/SUSE/hanadb_exporter
 Source:         hanadb_exporter-%{version}.tar.gz
 %if %{with test}
@@ -37,7 +37,7 @@ BuildRequires:  python3-mock
 BuildRequires:  python3-pytest
 %endif
 BuildRequires:  python3-setuptools
-Provides:       hanadb-exporter
+Provides:       hanadb_exporter = %{version}-%{release}
 BuildRequires:  fdupes
 BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
@@ -48,8 +48,10 @@ BuildArch:      noarch
 %description
 SAP HANA database metrics exporter
 
+%define shortname hanadb_exporter
+
 %prep
-%setup -q -n hanadb_exporter-%{version}
+%setup -q -n %{shortname}-%{version}
 
 %build
 python3 setup.py build
@@ -61,29 +63,29 @@ python3 setup.py install --root %{buildroot} --prefix=%{_prefix}
 rm -r %{buildroot}%{python3_sitelib}/tests
 
 # Add daemon files
-mkdir -p %{buildroot}%{oldsyscondir}/hanadb_exporter
-mkdir -p %{buildroot}%{_sysconfdir}/hanadb_exporter
-install -D -m 644 daemon/hanadb_exporter@.service %{buildroot}%{_unitdir}/hanadb_exporter@.service
+mkdir -p %{buildroot}%{oldsyscondir}/%{shortname}
+mkdir -p %{buildroot}%{_sysconfdir}/%{shortname}
+install -D -m 644 daemon/%{shortname}@.service %{buildroot}%{_unitdir}/%{name}@.service
 
 install -D -m 0644 config.json.example %{buildroot}%{_docdir}/%{name}/config.json.example
 install -D -m 0644 metrics.json %{buildroot}%{_docdir}/%{name}/metrics.json
 install -D -m 0644 logging_config.ini %{buildroot}%{_docdir}/%{name}/logging_config.ini
 
 %post
-%service_add_post hanadb_exporter@.service
-rm -rf  %{_sysconfdir}/hanadb_exporter/*
-ln -s %{_docdir}/hanadb_exporter/config.json.example %{_sysconfdir}/hanadb_exporter/config.json.example
-ln -s %{_docdir}/hanadb_exporter/metrics.json  %{_sysconfdir}/hanadb_exporter/metrics.json
-ln -s %{_docdir}/hanadb_exporter/logging_config.ini  %{_sysconfdir}/hanadb_exporter/logging_config.ini
+%service_add_post %{name}@.service
+rm -rf  %{_sysconfdir}/%{shortname}/*
+ln -s %{_docdir}/%{name}/config.json.example %{_sysconfdir}/%{shortname}/config.json.example
+ln -s %{_docdir}/%{name}/metrics.json  %{_sysconfdir}/%{shortname}/metrics.json
+ln -s %{_docdir}/%{name}/logging_config.ini  %{_sysconfdir}/%{shortname}/logging_config.ini
 
 %pre
-%service_add_pre hanadb_exporter@.service
+%service_add_pre %{name}@.service
 
 %preun
-%service_del_preun -n hanadb_exporter@.service
+%service_del_preun -n %{name}@.service
 
 %postun
-%service_del_postun -n hanadb_exporter@.service
+%service_del_postun -n %{name}@.service
 
 %if %{with test}
 %check
@@ -99,14 +101,14 @@ pytest tests
 %license LICENSE
 %endif
 %{python3_sitelib}/*
-%{_bindir}/hanadb_exporter
+%{_bindir}/%{shortname}
 
 %dir %{_sysconfdir}
-%dir %{oldsyscondir}/hanadb_exporter
-%dir %{_sysconfdir}/hanadb_exporter
+%dir %{oldsyscondir}/%{shortname}
+%dir %{_sysconfdir}/%{shortname}
 %{_docdir}/%{name}/config.json.example
 %{_docdir}/%{name}/metrics.json
 %{_docdir}/%{name}/logging_config.ini
-%{_unitdir}/hanadb_exporter@.service
+%{_unitdir}/%{name}@.service
 
 %changelog

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -164,7 +164,7 @@ class TestMain(object):
             mock.call('exporter sucessfully registered'),
             mock.call('starting to serve metrics')
         ])
-        mock_start_server.assert_called_once_with(9968, '0.0.0.0')
+        mock_start_server.assert_called_once_with(9668, '0.0.0.0')
         mock_sleep.assert_called_once_with(1)
 
     @mock.patch('hanadb_exporter.main.LOGGER')
@@ -231,7 +231,7 @@ class TestMain(object):
             mock.call('exporter sucessfully registered'),
             mock.call('starting to serve metrics')
         ])
-        mock_start_server.assert_called_once_with(9968, '0.0.0.0')
+        mock_start_server.assert_called_once_with(9668, '0.0.0.0')
         mock_sleep.assert_called_once_with(1)
 
     @mock.patch('hanadb_exporter.main.parse_arguments')


### PR DESCRIPTION
Update the package name to `prometheus-hanadb_exporter` (the old `hanadb_exporter` will be provided as well).

PD: The port number has been fixed to `9668`