### PR TITLE
Not export TYPE and HELP if there is not any record

### DIFF
--- a/hanadb_exporter/prometheus_exporter.py
+++ b/hanadb_exporter/prometheus_exporter.py
@@ -163,6 +163,10 @@ FROM m_database m;"""
                     self._logger.error(str(err))
                     continue  # Moving to the next iteration (query)
                 formatted_query_result = utils.format_query_result(query_result)
+                if not formatted_query_result:
+                    self._logger.warning(
+                        'Query %s ... has not returned any record', query.query)
+                    continue
                 for metric in query.metrics:
                     if metric.type == "gauge":
                         try:

--- a/prometheus-hanadb_exporter.changes
+++ b/prometheus-hanadb_exporter.changes
@@ -1,7 +1,13 @@
 -------------------------------------------------------------------
+Tue May  5 11:18:53 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.7.1 Fix the case where HELP and TYPE entries are exported
+even though there is not any record for that metric (bsc#1170717)
+
+-------------------------------------------------------------------
 Wed Apr 29 15:00:34 UTC 2020 - Julien ADAMEK <julien.adamek@suse.com>
 
-- Version 0.7.1 Fix and improve the README file (bsc#1170843) 
+- Fix and improve the README file (bsc#1170843)
 
 -------------------------------------------------------------------
 Tue Feb 11 13:31:52 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>


### PR DESCRIPTION
Fix the case where HELP and TYPE entries are exported even though there is not any record for that metric (bsc#1170717)

This error happens when  sap host agent is not running. 

PD: I'm just adopting the version `0.7.1` change, but we are not going to submit the changes until the whole testing is finished so we can wrap all the fixes in `0.7.1`