### PR TITLE
lookup for multiple configs

### DIFF
--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -26,8 +26,8 @@ from hanadb_exporter import db_manager
 LOGGER = logging.getLogger(__name__)
 # in new systems /etc/ folder is not used in favor of /usr/etc
 INIT_FILES = [
-       '/usr/etc/hanadb_exporter',
-      '/etc/hanadb_exporter'
+    '/etc/hanadb_exporter',
+    '/usr/etc/hanadb_exporter'
 ]
 METRICS_FILES = [
     '/etc/hanadb_exporter/metrics.json',

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -25,9 +25,9 @@ from hanadb_exporter import db_manager
 
 LOGGER = logging.getLogger(__name__)
 # in new systems /etc/ folder is not used in favor of /usr/etc
-CONFIG_FILES = [
-    '/etc/hanadb_exporter',
-    '/usr/etc/hanadb_exporter'
+CONFIG_FILES_DIR = [
+    '/etc/hanadb_exporter/',
+    '/usr/etc/hanadb_exporter/'
 ]
 METRICS_FILES = [
     '/etc/hanadb_exporter/metrics.json',
@@ -85,8 +85,9 @@ def setup_logging(config):
 
 def lookup_etc_folder(config_files_path):
     """
-    Find predefined files in default locations (METRICS and INIT folder)
+    Find predefined files in default locations (METRICS and CONFIG folder)
     This is used mainly because /etc location changed to /usr/etc in new systems
+    return full filename path (e.g: /etc/hanadb_exporter/filename.json)
     """
     for conf_file in config_files_path:
         if os.path.isfile(conf_file):
@@ -103,8 +104,10 @@ def run():
     if args.config is not None:
         config = parse_config(args.config)
     elif args.identifier is not None:
-        config_dir = lookup_etc_folder(CONFIG_FILES)
-        config = parse_config('{}/{}.json'.format(config_dir, args.identifier))
+        file_name = args.identifier + '.json'
+        # determine if file is /etc or /usr/etc
+        config_file = lookup_etc_folder([dirname + file_name for dirname in CONFIG_FILES_DIR])
+        config = parse_config(config_file)
 
     else:
         raise ValueError('configuration file or identifier must be used')

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -25,7 +25,7 @@ from hanadb_exporter import db_manager
 
 LOGGER = logging.getLogger(__name__)
 # in new systems /etc/ folder is not used in favor of /usr/etc
-INIT_FILES = [
+CONFIG_FILES = [
     '/etc/hanadb_exporter',
     '/usr/etc/hanadb_exporter'
 ]
@@ -83,16 +83,16 @@ def setup_logging(config):
     sys.excepthook = handle_exception
 
 
-def lookup_etc_folder(default_paths):
+def lookup_etc_folder(config_files_path):
     """
     Find predefined files in default locations (METRICS and INIT folder)
     This is used mainly because /etc location changed to /usr/etc in new systems
     """
-    for conf_file in default_paths:
+    for conf_file in config_files_path:
         if os.path.isfile(conf_file):
             return conf_file
     raise ValueError(
-        'configuration file does not exist in {}'.format(",".join(default_paths)))
+        'configuration file does not exist in {}'.format(",".join(config_files_path)))
 
 # Start up the server to expose the metrics.
 def run():
@@ -103,7 +103,7 @@ def run():
     if args.config is not None:
         config = parse_config(args.config)
     elif args.identifier is not None:
-        config_dir = lookup_etc_folder(INIT_FILES)
+        config_dir = lookup_etc_folder(CONFIG_FILES)
         config = parse_config('{}/{}.json'.format(config_dir, args.identifier))
 
     else:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -102,7 +102,7 @@ class TestMain(object):
         mock_isfile.side_effect = [False, False]
         with pytest.raises(ValueError) as err:
             main.lookup_etc_folder(main.METRICS_FILES)
-        assert 'metrics file does not exist in {}'.format(",".join(main.METRICS_FILES)) in str(err.value)
+        assert 'configuration file does not exist in {}'.format(",".join(main.METRICS_FILES)) in str(err.value)
 
     @mock.patch('hanadb_exporter.main.LOGGER')
     @mock.patch('hanadb_exporter.main.parse_arguments')
@@ -215,9 +215,8 @@ class TestMain(object):
             main.run()
 
         mock_parse_arguments.assert_called_once_with()
-        mock_parse_config.assert_called_once_with("{}/{}.json".format(main.INIT_FILES, 'config'))
+        mock_parse_config.assert_called_once_with("{}/{}.json".format("new_metrics", 'config'))
         mock_setup_logging.assert_called_once_with(config)
-        mock_lookup_etc_folder.assert_called_once_with()
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
             '10.10.10.10', 1234, user='user', password='pass',

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -92,16 +92,16 @@ class TestMain(object):
         ])
 
     @mock.patch('os.path.isfile')
-    def test_find_metrics_file(self, mock_isfile):
+    def test_lookup_etc_folder(self, mock_isfile):
         mock_isfile.return_value = True
-        metric_file = main.find_metrics_file()
+        metric_file = main.lookup_etc_folder(main.METRICS_FILES)
         assert metric_file == main.METRICS_FILES[0]
 
     @mock.patch('os.path.isfile')
-    def test_find_metrics_file_error(self, mock_isfile):
+    def test_lookup_etc_folder_error(self, mock_isfile):
         mock_isfile.side_effect = [False, False]
         with pytest.raises(ValueError) as err:
-            main.find_metrics_file()
+            main.lookup_etc_folder(main.METRICS_FILES)
         assert 'metrics file does not exist in {}'.format(",".join(main.METRICS_FILES)) in str(err.value)
 
     @mock.patch('hanadb_exporter.main.LOGGER')
@@ -168,7 +168,7 @@ class TestMain(object):
         mock_sleep.assert_called_once_with(1)
 
     @mock.patch('hanadb_exporter.main.LOGGER')
-    @mock.patch('hanadb_exporter.main.find_metrics_file')
+    @mock.patch('hanadb_exporter.main.lookup_etc_folder')
     @mock.patch('hanadb_exporter.main.parse_arguments')
     @mock.patch('hanadb_exporter.main.parse_config')
     @mock.patch('hanadb_exporter.main.setup_logging')
@@ -181,12 +181,12 @@ class TestMain(object):
     def test_run_defaults(
             self, mock_sleep, mock_get_logger, mock_start_server, mock_registry,
             mock_exporters, mock_db_manager, mock_setup_logging,
-            mock_parse_config, mock_parse_arguments, mock_find_metrics, mock_logger):
+            mock_parse_config, mock_parse_arguments, mock_lookup_etc_folder, mock_logger):
 
         mock_arguments = mock.Mock(config=None, metrics=None, identifier='config')
         mock_parse_arguments.return_value = mock_arguments
 
-        mock_find_metrics.return_value = 'new_metrics'
+        mock_lookup_etc_folder.return_value = 'new_metrics'
 
         config = {
             'hana': {
@@ -215,9 +215,9 @@ class TestMain(object):
             main.run()
 
         mock_parse_arguments.assert_called_once_with()
-        mock_parse_config.assert_called_once_with("{}/{}.json".format(main.CONFIG_FOLDER, 'config'))
+        mock_parse_config.assert_called_once_with("{}/{}.json".format(main.INIT_FILES, 'config'))
         mock_setup_logging.assert_called_once_with(config)
-        mock_find_metrics.assert_called_once_with()
+        mock_lookup_etc_folder.assert_called_once_with()
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
             '10.10.10.10', 1234, user='user', password='pass',

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -215,7 +215,7 @@ class TestMain(object):
             main.run()
 
         mock_parse_arguments.assert_called_once_with()
-        mock_parse_config.assert_called_once_with("{}/{}.json".format("new_metrics", 'config'))
+        mock_parse_config.assert_called_once_with("new_metrics")
         mock_setup_logging.assert_called_once_with(config)
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(


### PR DESCRIPTION
In the hana formula we are `copying` files from `/usr/etc` to `/etc`. But we shouldn't copy this files to `/etc`. This not coherent to next versions see last note at the end.

https://github.com/SUSE/saphanabootstrap-formula/blob/master/hana/monitoring.sls#L55-L68

we should keep them in `/usr/etc` and having the exporter look in both folder. 

The metric folder is in fact already lookedup. This pr extends the same mechanism to mimic the same  for the `init` folder


Once this pr merged we can remove the 2 states in formula and adapt the rest accordingly


`/usr/etc` -> https://kubic.opensuse.org/blog/2019-12-05-usr-etc/