### PR TITLE
Use systemd notify to set correctly the READY state

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,7 @@
 {
   "exposition_port": 9668,
   "multi_tenant": true,
-  "timeout": 600,
+  "timeout": 30,
   "hana": {
     "host": "localhost",
     "port": 30013,

--- a/daemon/hanadb_exporter@.service
+++ b/daemon/hanadb_exporter@.service
@@ -3,8 +3,8 @@ Description=SAP HANA database metrics exporter
 Documentation=https://github.com/SUSE/hanadb_exporter
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/hanadb_exporter --identifier %i
+Type=notify
+ExecStart=/usr/bin/hanadb_exporter --identifier %i --daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use systemd notify option to state that the daemon started properly.

As the exporter has an initial timeout to connect to the database, now the daemon will be put as correctly started after this initial loop.

If the exporter is started without being a daemon the functionality is untouched.

This helps the Pacemaker cluster to correctly monitor the start of the resource.

https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=

Besides this, I have reduced the timeout value from 600 to 30, to have a more reasonable value (I will do the same in the `sapahanbootstrap-formula`)