### PR TITLE
Implement the version flag

### DIFF
--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.3"

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -20,6 +20,7 @@ import argparse
 from prometheus_client.core import REGISTRY
 from prometheus_client import start_http_server
 
+from hanadb_exporter import __version__
 from hanadb_exporter import prometheus_exporter
 from hanadb_exporter import db_manager
 from hanadb_exporter import utils
@@ -62,6 +63,9 @@ def parse_arguments():
     parser.add_argument(
         "-v", "--verbosity",
         help="Python logging level. Options: DEBUG, INFO, WARN, ERROR (INFO by default)")
+    parser.add_argument(
+        "-V", "--version", action="store_true",
+        help="Print the hanadb_exporter version")
     args = parser.parse_args()
     return args
 
@@ -106,6 +110,10 @@ def run():
     Main execution
     """
     args = parse_arguments()
+    if args.version:
+        # pylint:disable=C0325
+        print("hanadb_exporter %s" % (__version__))
+        return
     if args.config is not None:
         config = parse_config(args.config)
     elif args.identifier is not None:

--- a/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
+++ b/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package prometheus-hanadb_exporter
 #
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,7 +12,7 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 
 %if 0%{?suse_version} < 1500
 %bcond_with test
@@ -30,7 +30,7 @@ Release:        0
 Summary:        SAP HANA database metrics exporter
 License:        Apache-2.0
 Group:          System/Monitoring
-Url:            https://github.com/SUSE/hanadb_exporter
+URL:            https://github.com/SUSE/hanadb_exporter
 Source:         %{name}-%{version}.tar.gz
 %if %{with test}
 BuildRequires:  python3-pytest
@@ -40,8 +40,8 @@ Provides:       hanadb_exporter = %{version}-%{release}
 BuildRequires:  fdupes
 BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
-Requires:       python3-shaptools >= 0.3.2
 Requires:       python3-prometheus_client >= 0.6.0
+Requires:       python3-shaptools >= 0.3.2
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
- Implement the `--version` flag (https://github.com/SUSE/hanadb_exporter/issues/88)
- Upgrade package version to `0.7.3` correctly
- Update the `spec` file with the latest information to sync with the shipped version
 