### PR TITLE
Fixing empty system replication panel 91#issue-918975015

### DIFF
--- a/dashboards/sap-hana.json
+++ b/dashboards/sap-hana.json
@@ -3029,7 +3029,7 @@
       ],
       "targets": [
         {
-          "expr": "hanadb_sr_takeover_replication_status{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+          "expr": "hanadb_sr_takeover_replication_status{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -3037,7 +3037,7 @@
           "refId": "A"
         },
         {
-          "expr": "hanadb_sr_takeover_duration_time_seconds{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+          "expr": "hanadb_sr_takeover_duration_time_seconds{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -3045,7 +3045,7 @@
           "refId": "B"
         },
         {
-          "expr": "hanadb_sr_takeover_log_position_bigint{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+          "expr": "hanadb_sr_takeover_log_position_bigint{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -3054,7 +3054,7 @@
           "refId": "C"
         },
         {
-          "expr": "hanadb_sr_takeover_shipped_log_position_bigint{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+          "expr": "hanadb_sr_takeover_shipped_log_position_bigint{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,8 +1,0 @@
--------------------------------------------------------------------
-Fri Jun 11 19:30:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
-
-- The HANA system replication history panel could not show data, because of 
-  the node_name variable does not match to the output string from the exporter. 
-  Changing "host=" value to "src_host=" solves the issue. Fix is tested with 
-  HANA SPS040 and HANA SPS050.
-  https://bugzilla.suse.com/show_bug.cgi?id=1187243

--- a/hanadb_exporter.changes
+++ b/hanadb_exporter.changes
@@ -1,0 +1,8 @@
+-------------------------------------------------------------------
+Fri Jun 11 19:30:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
+
+- The HANA system replication history panel could not show data, because of 
+  the node_name variable does not match to the output string from the exporter. 
+  Changing "host=" value to "src_host=" solves the issue. Fix is tested with 
+  HANA SPS040 and HANA SPS050.
+  https://bugzilla.suse.com/show_bug.cgi?id=1187243

--- a/packaging/obs/grafana-sap-hana-dashboards/grafana-sap-hana-dashboards.changes
+++ b/packaging/obs/grafana-sap-hana-dashboards/grafana-sap-hana-dashboards.changes
@@ -6,7 +6,8 @@ Fri Jun 11 19:30:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
     the node_name variable does not match to the output string from the exporter. 
     Changing "host=" value to "src_host=" solves the issue. Fix is tested with 
     HANA SPS040 and HANA SPS050.
-  * bgz#1187243
+    (bgz#1187243)
+
 -------------------------------------------------------------------
 Wed Sep 16 13:35:38 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>
 

--- a/packaging/obs/grafana-sap-hana-dashboards/grafana-sap-hana-dashboards.changes
+++ b/packaging/obs/grafana-sap-hana-dashboards/grafana-sap-hana-dashboards.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Jun 11 19:30:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
+
+- Release 1.0.3
+  * The HANA system replication history panel could not show data, because of 
+    the node_name variable does not match to the output string from the exporter. 
+    Changing "host=" value to "src_host=" solves the issue. Fix is tested with 
+    HANA SPS040 and HANA SPS050.
+  * bgz#1187243
+-------------------------------------------------------------------
 Wed Sep 16 13:35:38 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>
 
 - Release 1.0.2


### PR DESCRIPTION
changing host= value pair to src_host= for the System Replication Takeover History panel
The changes was validated with SAP HANA 2.0 SPS05 rev. 52 and SAP HANA 2.0 SPS04 Rev.48.04
This PR fix https://github.com/SUSE/hanadb_exporter/issues/91#issue-918975015