### PR TITLE
Handling HANA scale-out/failover usecases

### DIFF
--- a/hanadb_exporter/utils.py
+++ b/hanadb_exporter/utils.py
@@ -59,6 +59,7 @@ def check_hana_range(hana_version, availability_range):
             and version.LooseVersion(hana_version) <= version.LooseVersion(availability_range[1])
     raise ValueError('provided availability range does not have the correct number of elements')
 
+
 def systemd_ready():
     """
     Notify the systemd deamon that the service is READY
@@ -72,3 +73,7 @@ def systemd_ready():
         addr = '\0' + addr[1:]
     soc.connect(addr)
     soc.sendall(b'READY=1')
+
+
+def get_hostname():
+    return socket.gethostname()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -138,9 +138,10 @@ class TestMain(object):
         mock_arguments = mock.Mock(config='config', metrics='metrics', daemon=False, version=False)
         mock_parse_arguments.return_value = mock_arguments
 
+        host = '10.10.10.10'
         config = {
             'hana': {
-                'host': '10.10.10.10',
+                'host': host,
                 'port': 1234,
                 'user': 'user',
                 'password': 'pass'
@@ -154,6 +155,8 @@ class TestMain(object):
 
         db_instance = mock.Mock()
         db_instance.get_connectors.return_value = 'connectors'
+        db_instance.get_database_hosts.return_value = [host]
+        db_instance.get_active_master_host.return_value = host
         mock_db_manager.return_value = db_instance
 
         mock_collector = mock.Mock()
@@ -169,7 +172,7 @@ class TestMain(object):
         mock_setup_logging.assert_called_once_with(config)
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
-            '10.10.10.10', 1234, user='user', password='pass',
+            host, 1234, user='user', password='pass',
             userkey=None, multi_tenant=True, timeout=30)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
@@ -206,10 +209,10 @@ class TestMain(object):
         mock_parse_arguments.return_value = mock_arguments
 
         mock_lookup_etc_folder.return_value = 'new_metrics'
-
+        host = '10.10.10.10'
         config = {
             'hana': {
-                'host': '10.10.10.10',
+                'host': host,
                 'port': 1234,
                 'user': 'user',
                 'password': 'pass'
@@ -223,6 +226,8 @@ class TestMain(object):
 
         db_instance = mock.Mock()
         db_instance.get_connectors.return_value = 'connectors'
+        db_instance.get_database_hosts.return_value = [host]
+        db_instance.get_active_master_host.return_value = host
         mock_db_manager.return_value = db_instance
 
         mock_collector = mock.Mock()
@@ -238,7 +243,7 @@ class TestMain(object):
         mock_setup_logging.assert_called_once_with(config)
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
-            '10.10.10.10', 1234, user='user', password='pass',
+            host, 1234, user='user', password='pass',
             userkey=None, multi_tenant=True, timeout=30)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
@@ -321,9 +326,10 @@ class TestMain(object):
             'password': 'db_pass'
         }
 
+        host = '10.10.10.10'
         config = {
             'hana': {
-                'host': '10.10.10.10',
+                'host': host,
                 'port': 1234,
                 'aws_secret_name': 'db_secret',
                 'user': 'user',
@@ -339,6 +345,8 @@ class TestMain(object):
 
         db_instance = mock.Mock()
         db_instance.get_connectors.return_value = 'connectors'
+        db_instance.get_database_hosts.return_value = [host]
+        db_instance.get_active_master_host.return_value = host
         mock_db_manager.return_value = db_instance
 
         mock_collector = mock.Mock()
@@ -354,7 +362,7 @@ class TestMain(object):
         mock_setup_logging.assert_called_once_with(config)
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
-            '10.10.10.10', 1234, user='db_user', password='db_pass',
+            host, 1234, user='db_user', password='db_pass',
             userkey=None, multi_tenant=True, timeout=30)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
@@ -365,7 +373,7 @@ class TestMain(object):
             mock.call('AWS secret name is going to be used to read the database username and password'),
             mock.call('exporter successfully registered'),
             mock.call('starting to serve metrics')
-        ])
+        ], any_order=True)
         mock_start_server.assert_called_once_with(9668, '0.0.0.0')
         mock_sleep.assert_called_once_with(1)
         assert mock_systemd.call_count == 0


### PR DESCRIPTION
### SCALE-OUT/FAILOVER
- The idea is to run the exporter on all the hana-db hosts. 
- The exporter on each host will make sure that the master host is up.
> On Master host, the exporter will emit the HANA system metrics, the exporters on the other hosts will be on standby mode, and will reply only with python metrics to any curl command. 

> The exporter installation will fail on all nodes, if it is not able to connect to master node.

- To enable this mode **one new config** is added
`scale_out_mode` a boolean flag to enable this feature, it is false by default. 

### Examples:

- Standby mode on worker nodes
```
 INFO:shaptools.hdb_connector.connectors.base_connector:query records: [('imdbworker02',), ('imdbworker01',), ('imdbmaster',)]
INFO:hanadb_exporter.db_manager:Current HANA system hosts: ['imdbworker02', 'imdbworker01', 'imdbmaster']
current_host imdbworker02
INFO:hanadb_exporter.main:scale_out_mode mode is enabled
INFO:hanadb_exporter.main:Exporter is in stand by mode for scale-out handling
INFO:shaptools.hdb_connector.connectors.base_connector:executing sql query: SELECT HOST from M_LANDSCAPE_HOST_CONFIGURATION WHERE HOST_ACTIVE='YES'
INFO:shaptools.hdb_connector.connectors.base_connector:query records: [('imdbworker02',), ('imdbworker01',), ('imdbmaster',)]
INFO:hanadb_exporter.db_manager:Current HANA system hosts: ['imdbworker02', 'imdbworker01', 'imdbmaster']
INFO:hanadb_exporter.main:starting to serve metrics
```

curl response:

```
[ec2-user@imdbworker02 ~]$ curl localhost:9668
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 215.0
python_gc_objects_collected_total{generation="1"} 326.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 91.0
python_gc_collections_total{generation="1"} 8.0
python_gc_collections_total{generation="2"} 0.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="8",patchlevel="4",version="3.8.4"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 4.07556096e+08
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.3619968e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.62826749985e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.22999999999999998
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 8.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
```



- Installation failure due to connection failure to system-db on all host
```
ERROR:hanadb_exporter.db_manager:the connection to the system database failed. error message: connection failed: [Errno -2] Name or service not known
Traceback (most recent call last):
  File "/home/ec2-user/.local/bin/hanadb_exporter", line 9, in <module>
    main.run()
  File "/home/ec2-user/.local/lib/python3.8/site-packages/hanadb_exporter/main.py", line 189, in run
    start(
  File "/home/ec2-user/.local/lib/python3.8/site-packages/hanadb_exporter/main.py", line 117, in start
    db_manager.start(
  File "/home/ec2-user/.local/lib/python3.8/site-packages/hanadb_exporter/db_manager.py", line 138, in start
    raise hdb_connector.connectors.base_connector.ConnectionError(
shaptools.hdb_connector.connectors.base_connector.ConnectionError: timeout reached connecting the System database
```
