### PR TITLE
Enable ssl connection

### DIFF
--- a/.github/workflows/exporter-ci.yml
+++ b/.github/workflows/exporter-ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   obs-commit:
     needs: test
-    if: github.ref == 'refs/heads/master'
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     container: shap/continuous_deliver
     env:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ important items in the configuration file:
   - `hana.userkey`: Stored user key. This is the secure option if you don't want to have the password in the configuration file. The `userkey` and `user/password` are self exclusive being the first the default if both options are set.
   - `hana.user`: An existing user with access right to the SAP HANA database.
   - `hana.password`: Password of an existing user.
+  - `hana.ssl`: Enable SSL connection (False by default). Only available for `dbapi` connector
+  - `hana.ssl_validate_cert`: Enable SSL certification validation. This field is required by HANA cloud. Only available for `dbapi` connector
   - `logging.config_file`: Python logging system configuration file (by default WARN and ERROR level messages will be sent to the syslog)
   - `logging.log_file`: Logging file (/var/log/hanadb_exporter.log by default)
 

--- a/config.json.example
+++ b/config.json.example
@@ -6,7 +6,8 @@
     "host": "localhost",
     "port": 30013,
     "user": "SYSTEM",
-    "password": "PASSWORD"
+    "password": "PASSWORD",
+    "ssl": false
   },
   "logging": {
     "config_file": "./logging_config.ini",

--- a/config.json.example
+++ b/config.json.example
@@ -7,7 +7,8 @@
     "port": 30013,
     "user": "SYSTEM",
     "password": "PASSWORD",
-    "ssl": false
+    "ssl": false,
+    "ssl_validate_cert": false,
   },
   "logging": {
     "config_file": "./logging_config.ini",

--- a/hanadb_exporter/__init__.py
+++ b/hanadb_exporter/__init__.py
@@ -8,4 +8,4 @@ SAP HANA database data exporter
 :since: 2019-05-09
 """
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -108,7 +108,7 @@ WHERE COORDINATOR_TYPE='MASTER' AND SQL_PORT<>0"""
             'password': password,
             'RECONNECT': 'FALSE',
             'encrypt': ssl,
-            'sslValidateCertificate': ssl,
+            'sslValidateCertificate': kwargs.get('ssl_validate_cert', False) if ssl else False,
             'sslTrustStore': trust_store if ssl and CERTIFI_INSTALLED else None
         }
 
@@ -126,12 +126,14 @@ WHERE COORDINATOR_TYPE='MASTER' AND SQL_PORT<>0"""
             multi_tenant (bool): Connect to all tenants checking the data in the System database
             timeout (int, opt): Timeout in seconds to connect to the System database
             ssl (bool, opt): Enable SSL connection
+            ssl_validate_cert (bool, opt): Validate SSL certificate. Required in HANA cloud
         """
         connection_data = self._get_connection_data(
             kwargs.get('userkey', None),
             kwargs.get('user', ''),
             kwargs.get('password', ''),
-            ssl=kwargs.get('ssl', False)
+            ssl=kwargs.get('ssl', False),
+            ssl_validate_cert=kwargs.get('ssl_validate_cert', False)
         )
 
         current_time = time.time()

--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -14,6 +14,12 @@ import time
 from shaptools import hdb_connector
 from hanadb_exporter import utils
 
+try:
+    import certifi
+    CERTIFI_INSTALLED = True
+except ImportError:
+    CERTIFI_INSTALLED = False
+
 RECONNECTION_INTERVAL = 15
 
 
@@ -69,7 +75,7 @@ WHERE COORDINATOR_TYPE='MASTER' AND SQL_PORT<>0"""
                 self._logger.warn(
                     'Could not connect to TENANT database %s with error: %s', database, str(err))
 
-    def _get_connection_data(self, userkey, user, password):
+    def _get_connection_data(self, userkey, user, password, **kwargs):
         """
         Check that provided user data is valid. user/password pair or userkey must be provided
         """
@@ -87,10 +93,24 @@ WHERE COORDINATOR_TYPE='MASTER' AND SQL_PORT<>0"""
             raise ValueError(
                 'Provided user data is not valid. userkey or user/password pair must be provided')
 
-        return {'userkey': userkey,
-                'user': user,
-                'password': password,
-                'RECONNECT': 'FALSE'}
+        ssl = kwargs.get('ssl', False)
+        if ssl:
+            self._logger.info('Using ssl connection...')
+
+        if ssl and CERTIFI_INSTALLED:
+            trust_store = certifi.where()
+        elif ssl:
+            self._logger.warn('certifi package is not installed. Using the default ssl pem key...')
+
+        return {
+            'userkey': userkey,
+            'user': user,
+            'password': password,
+            'RECONNECT': 'FALSE',
+            'encrypt': ssl,
+            'sslValidateCertificate': ssl,
+            'sslTrustStore': trust_store if ssl and CERTIFI_INSTALLED else None
+        }
 
     def start(self, host, port, **kwargs):
         """
@@ -105,9 +125,15 @@ WHERE COORDINATOR_TYPE='MASTER' AND SQL_PORT<>0"""
             password (str): System database user password
             multi_tenant (bool): Connect to all tenants checking the data in the System database
             timeout (int, opt): Timeout in seconds to connect to the System database
+            ssl (bool, opt): Enable SSL connection
         """
         connection_data = self._get_connection_data(
-            kwargs.get('userkey', None), kwargs.get('user', ''), kwargs.get('password', ''))
+            kwargs.get('userkey', None),
+            kwargs.get('user', ''),
+            kwargs.get('password', ''),
+            ssl=kwargs.get('ssl', False)
+        )
+
         current_time = time.time()
         timeout = current_time + kwargs.get('timeout', 600)
         while current_time <= timeout:

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -145,7 +145,8 @@ def run():
             userkey=hana_config.get('userkey', None),
             multi_tenant=config.get('multi_tenant', True),
             timeout=config.get('timeout', 30),
-            ssl=config.get('ssl', False))
+            ssl=hana_config.get('ssl', False),
+            ssl_validate_cert=hana_config.get('ssl_validate_cert', False))
     except KeyError as err:
         raise KeyError('Configuration file {} is malformed: {} not found'.format(args.config, err))
 

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -144,7 +144,8 @@ def run():
             password=hana_config.get('password', ''),
             userkey=hana_config.get('userkey', None),
             multi_tenant=config.get('multi_tenant', True),
-            timeout=config.get('timeout', 30))
+            timeout=config.get('timeout', 30),
+            ssl=config.get('ssl', False))
     except KeyError as err:
         raise KeyError('Configuration file {} is malformed: {} not found'.format(args.config, err))
 

--- a/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
+++ b/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
@@ -34,6 +34,7 @@ URL:            https://github.com/SUSE/hanadb_exporter
 Source:         %{name}-%{version}.tar.gz
 %if %{with test}
 BuildRequires:  python3-pytest
+BuildRequires:  python3-certifi
 %endif
 BuildRequires:  python3-setuptools
 Provides:       hanadb_exporter = %{version}-%{release}

--- a/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
+++ b/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
@@ -42,6 +42,7 @@ BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
 Requires:       python3-prometheus_client >= 0.6.0
 Requires:       python3-shaptools >= 0.3.2
+Recommends:     python3-certifi
 BuildArch:      noarch
 
 %description

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 prometheus-client>=0.6.0
 git+https://github.com/SUSE/shaptools.git#egg=shaptools>=0.3.2
 pyhdb>=0.3.4
+certifi>=2018.1.18

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -177,7 +177,8 @@ class TestDatabaseManager(object):
         mock_api.API = 'dbapi'
         connection_data = self._db_manager._get_connection_data('userkey', '', '')
         assert connection_data == {
-            'userkey': 'userkey', 'user': '', 'password': '', 'RECONNECT': 'FALSE'}
+            'userkey': 'userkey', 'user': '', 'password': '', 'RECONNECT': 'FALSE',
+            'encrypt': False, 'sslValidateCertificate': False, 'sslTrustStore': None}
         logger.assert_called_once_with(
             'stored user key %s will be used to connect to the database', 'userkey')
         assert logger_warn.call_count == 0
@@ -190,7 +191,8 @@ class TestDatabaseManager(object):
         mock_api.API = 'dbapi'
         connection_data = self._db_manager._get_connection_data('userkey', 'user', '')
         assert connection_data == {
-            'userkey': 'userkey', 'user': 'user', 'password': '', 'RECONNECT': 'FALSE'}
+            'userkey': 'userkey', 'user': 'user', 'password': '', 'RECONNECT': 'FALSE',
+            'encrypt': False, 'sslValidateCertificate': False, 'sslTrustStore': None}
         logger.assert_called_once_with(
             'stored user key %s will be used to connect to the database', 'userkey')
         logger_warn.assert_called_once_with(
@@ -199,13 +201,28 @@ class TestDatabaseManager(object):
     @mock.patch('hanadb_exporter.db_manager.hdb_connector')
     @mock.patch('logging.Logger.info')
     def test_get_connection_data_pass(self, logger, mock_api):
-
         mock_api.API = 'dbapi'
         connection_data = self._db_manager._get_connection_data(None, 'user', 'pass')
         assert connection_data == {
-            'userkey': None, 'user': 'user', 'password': 'pass', 'RECONNECT': 'FALSE'}
+            'userkey': None, 'user': 'user', 'password': 'pass', 'RECONNECT': 'FALSE',
+            'encrypt': False, 'sslValidateCertificate': False, 'sslTrustStore': None}
         logger.assert_called_once_with(
             'user/password combination will be used to connect to the databse')
+
+    @mock.patch('certifi.where')
+    @mock.patch('hanadb_exporter.db_manager.hdb_connector')
+    @mock.patch('logging.Logger.info')
+    def test_get_connection_ssl(self, logger, mock_api, mock_where):
+        mock_where.return_value = 'my.pem'
+        mock_api.API = 'dbapi'
+        connection_data = self._db_manager._get_connection_data(None, 'user', 'pass', ssl=True)
+        assert connection_data == {
+            'userkey': None, 'user': 'user', 'password': 'pass', 'RECONNECT': 'FALSE',
+            'encrypt': True, 'sslValidateCertificate': True, 'sslTrustStore': 'my.pem'}
+        logger.assert_has_calls([
+            mock.call('user/password combination will be used to connect to the databse'),
+            mock.call('Using ssl connection...')
+        ])
 
     @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
     @mock.patch('logging.Logger.error')

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -215,7 +215,8 @@ class TestDatabaseManager(object):
     def test_get_connection_ssl(self, logger, mock_api, mock_where):
         mock_where.return_value = 'my.pem'
         mock_api.API = 'dbapi'
-        connection_data = self._db_manager._get_connection_data(None, 'user', 'pass', ssl=True)
+        connection_data = self._db_manager._get_connection_data(
+            None, 'user', 'pass', ssl=True, ssl_validate_cert=True)
         assert connection_data == {
             'userkey': None, 'user': 'user', 'password': 'pass', 'RECONNECT': 'FALSE',
             'encrypt': True, 'sslValidateCertificate': True, 'sslTrustStore': 'my.pem'}

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -144,7 +144,8 @@ class TestMain(object):
                 'port': 1234,
                 'user': 'user',
                 'password': 'pass',
-                'ssl': True
+                'ssl': True,
+                'ssl_validate_cert': True
             },
             'logging': {
                 'log_file': 'my_file',
@@ -171,7 +172,7 @@ class TestMain(object):
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
             '10.10.10.10', 1234, user='user', password='pass',
-            userkey=None, multi_tenant=True, timeout=30, ssl=False)
+            userkey=None, multi_tenant=True, timeout=30, ssl=True, ssl_validate_cert=True)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
             connectors='connectors', metrics_file='metrics')
@@ -240,7 +241,7 @@ class TestMain(object):
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
             '10.10.10.10', 1234, user='user', password='pass',
-            userkey=None, multi_tenant=True, timeout=30, ssl=False)
+            userkey=None, multi_tenant=True, timeout=30, ssl=False, ssl_validate_cert=False)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
             connectors='connectors', metrics_file='new_metrics')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -143,7 +143,8 @@ class TestMain(object):
                 'host': '10.10.10.10',
                 'port': 1234,
                 'user': 'user',
-                'password': 'pass'
+                'password': 'pass',
+                'ssl': True
             },
             'logging': {
                 'log_file': 'my_file',
@@ -170,7 +171,7 @@ class TestMain(object):
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
             '10.10.10.10', 1234, user='user', password='pass',
-            userkey=None, multi_tenant=True, timeout=30)
+            userkey=None, multi_tenant=True, timeout=30, ssl=False)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
             connectors='connectors', metrics_file='metrics')
@@ -239,7 +240,7 @@ class TestMain(object):
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
             '10.10.10.10', 1234, user='user', password='pass',
-            userkey=None, multi_tenant=True, timeout=30)
+            userkey=None, multi_tenant=True, timeout=30, ssl=False)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
             connectors='connectors', metrics_file='new_metrics')


### PR DESCRIPTION
Some HANA databases enforce ssl usage when `global.ini / communication / sslenforce = true` is configured. In those cases we need to enable some different options in the hdbcli communcation. This PR implements those changes.

Fix for: https://github.com/SUSE/hanadb_exporter/issues/95