### PR TITLE
Add AWS Secrets Manager support

### DIFF
--- a/hanadb_exporter/db_manager.py
+++ b/hanadb_exporter/db_manager.py
@@ -82,7 +82,7 @@ WHERE COORDINATOR_TYPE='MASTER' AND SQL_PORT<>0"""
                 self._logger.warn(
                     'userkey will be used to create the connection. user/password are omitted')
         elif user and password:
-            self._logger.info('user/password combination will be used to connect to the databse')
+            self._logger.info('user/password combination will be used to connect to the database')
         else:
             raise ValueError(
                 'Provided user data is not valid. userkey or user/password pair must be provided')

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -1,0 +1,60 @@
+"""
+Unitary tests for exporters/secrets_manager.py.
+
+:author: elturkym
+
+:since: 2021-07-15
+"""
+
+import json
+import logging
+
+import boto3
+import requests
+from botocore.exceptions import ClientError
+from requests.exceptions import HTTPError
+
+EC2_INFO_URL = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+LOGGER = logging.getLogger(__name__)
+
+
+class SecretsManagerError(ValueError):
+    """
+    Unable to retrieve secret details
+    """
+
+
+def get_db_credentials(secret_name):
+    LOGGER.info('retrieving AWS secret details')
+
+    ec2_info_response = requests.get(EC2_INFO_URL)
+
+    try:
+        ec2_info_response.raise_for_status()
+    except HTTPError as e:
+        raise SecretsManagerError("EC2 information request failed") from e
+
+    ec2_info = ec2_info_response.json()
+    region_name = ec2_info["region"]
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    # In this sample we only handle the specific exceptions for the 'GetSecretValue' API.
+    # See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+    # We rethrow the exception by default.
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+    except ClientError as e:
+        raise SecretsManagerError("Couldn't retrieve secret details") from e
+    else:
+        # Decrypts secret using the associated KMS CMK.]
+        secret = get_secret_value_response['SecretString']
+        return json.loads(secret)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 prometheus-client>=0.6.0
 git+https://github.com/SUSE/shaptools.git#egg=shaptools>=0.3.2
 pyhdb>=0.3.4
+boto3
+requests

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -205,7 +205,7 @@ class TestDatabaseManager(object):
         assert connection_data == {
             'userkey': None, 'user': 'user', 'password': 'pass', 'RECONNECT': 'FALSE'}
         logger.assert_called_once_with(
-            'user/password combination will be used to connect to the databse')
+            'user/password combination will be used to connect to the database')
 
     @mock.patch('hanadb_exporter.db_manager.hdb_connector.connectors.base_connector')
     @mock.patch('logging.Logger.error')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -177,7 +177,7 @@ class TestMain(object):
 
         mock_registry.assert_called_once_with(mock_collector)
         mock_logger.info.assert_has_calls([
-            mock.call('exporter sucessfully registered'),
+            mock.call('exporter successfully registered'),
             mock.call('starting to serve metrics')
         ])
         mock_start_server.assert_called_once_with(9668, '0.0.0.0')
@@ -246,7 +246,7 @@ class TestMain(object):
 
         mock_registry.assert_called_once_with(mock_collector)
         mock_logger.info.assert_has_calls([
-            mock.call('exporter sucessfully registered'),
+            mock.call('exporter successfully registered'),
             mock.call('starting to serve metrics')
         ])
         mock_start_server.assert_called_once_with(9668, '0.0.0.0')
@@ -296,3 +296,76 @@ class TestMain(object):
         mock_db_manager.assert_called_once_with()
         assert 'Configuration file {} is malformed: {} not found'.format(
             'config', '\'host\'') in str(err.value)
+
+    @mock.patch('hanadb_exporter.utils.systemd_ready')
+    @mock.patch('hanadb_exporter.main.LOGGER')
+    @mock.patch('hanadb_exporter.main.parse_arguments')
+    @mock.patch('hanadb_exporter.main.parse_config')
+    @mock.patch('hanadb_exporter.main.setup_logging')
+    @mock.patch('hanadb_exporter.main.db_manager.DatabaseManager')
+    @mock.patch('hanadb_exporter.main.prometheus_exporter.SapHanaCollectors')
+    @mock.patch('hanadb_exporter.main.REGISTRY.register')
+    @mock.patch('hanadb_exporter.main.start_http_server')
+    @mock.patch('logging.getLogger')
+    @mock.patch('time.sleep')
+    @mock.patch('hanadb_exporter.main.secrets_manager.get_db_credentials')
+    def test_run_secret_manager(
+            self, mock_secret_manager, mock_sleep, mock_get_logger, mock_start_server, mock_registry,
+            mock_exporters, mock_db_manager, mock_setup_logging,
+            mock_parse_config, mock_parse_arguments, mock_logger, mock_systemd):
+
+        mock_arguments = mock.Mock(config='config', metrics='metrics', daemon=False, version=False)
+        mock_parse_arguments.return_value = mock_arguments
+        mock_secret_manager.return_value = {
+            'username': 'db_user',
+            'password': 'db_pass'
+        }
+
+        config = {
+            'hana': {
+                'host': '10.10.10.10',
+                'port': 1234,
+                'aws_secret_name': 'db_secret',
+                'user': 'user',
+                'password': 'pass'
+            },
+            'logging': {
+                'log_file': 'my_file',
+                'config_file': 'my_config_file'
+            }
+        }
+
+        mock_parse_config.return_value = config
+
+        db_instance = mock.Mock()
+        db_instance.get_connectors.return_value = 'connectors'
+        mock_db_manager.return_value = db_instance
+
+        mock_collector = mock.Mock()
+        mock_exporters.return_value = mock_collector
+
+        mock_sleep.side_effect = Exception
+
+        with pytest.raises(Exception):
+            main.run()
+
+        mock_parse_arguments.assert_called_once_with()
+        mock_parse_config.assert_called_once_with(mock_arguments.config)
+        mock_setup_logging.assert_called_once_with(config)
+        mock_db_manager.assert_called_once_with()
+        db_instance.start.assert_called_once_with(
+            '10.10.10.10', 1234, user='db_user', password='db_pass',
+            userkey=None, multi_tenant=True, timeout=30)
+        db_instance.get_connectors.assert_called_once_with()
+        mock_exporters.assert_called_once_with(
+            connectors='connectors', metrics_file='metrics')
+
+        mock_registry.assert_called_once_with(mock_collector)
+        mock_logger.info.assert_has_calls([
+            mock.call('AWS secret name is going to be used to read the database username and password'),
+            mock.call('exporter successfully registered'),
+            mock.call('starting to serve metrics')
+        ])
+        mock_start_server.assert_called_once_with(9668, '0.0.0.0')
+        mock_sleep.assert_called_once_with(1)
+        assert mock_systemd.call_count == 0

--- a/tests/secrets_manager_test.py
+++ b/tests/secrets_manager_test.py
@@ -1,0 +1,76 @@
+"""
+Unitary tests for exporters/secrets_manager.py.
+
+:author: elturkym
+
+:since: 2021-07-15
+"""
+
+import json
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import pytest
+
+from hanadb_exporter import secrets_manager
+from botocore.exceptions import ClientError
+from requests.exceptions import HTTPError
+
+
+class TestSecretsManager(object):
+    """
+    Unitary tests for hanadb_exporter/secrets_manager.py.
+    """
+
+    @mock.patch('hanadb_exporter.secrets_manager.LOGGER')
+    @mock.patch('hanadb_exporter.secrets_manager.requests')
+    @mock.patch('hanadb_exporter.secrets_manager.boto3.session')
+    def test_get_db_credentials(self, mock_boto3, mock_requests, mock_logger):
+        mock_ec2_response = mock.Mock()
+        mock_requests.get.return_value = mock_ec2_response
+        mock_ec2_response.json.return_value = json.loads('{"region":"test_region"}')
+        mock_session = mock.Mock()
+        mock_sm_client = mock.Mock()
+        mock_boto3.Session.return_value = mock_session
+        mock_session.client.return_value = mock_sm_client
+        mock_sm_client.get_secret_value.return_value = json.loads(
+            '{"SecretString" : "{\\"username\\": \\"db_user\\", \\"password\\":\\"db_pass\\"}"}')
+
+        actual_secret = secrets_manager.get_db_credentials("test_secret")
+
+        mock_session.client.assert_called_once_with(service_name='secretsmanager', region_name='test_region')
+        mock_sm_client.get_secret_value.assert_called_once_with(SecretId='test_secret')
+        mock_logger.info.assert_has_calls([
+            mock.call('retrieving AWS secret details')
+        ])
+        assert actual_secret['username'] == 'db_user'
+        assert actual_secret['password'] == 'db_pass'
+
+    @mock.patch('hanadb_exporter.secrets_manager.requests')
+    def test_get_db_credentials_ec2_request_error(self, mock_requests):
+        ec2_info_response = mock.Mock()
+        mock_requests.get.return_value = ec2_info_response
+        ec2_info_response.raise_for_status.side_effect=HTTPError
+
+        with pytest.raises(secrets_manager.SecretsManagerError) as err:
+            secrets_manager.get_db_credentials("test_secret")
+        assert 'EC2 information request failed' in str(err.value)
+
+    @mock.patch('hanadb_exporter.secrets_manager.requests')
+    @mock.patch('hanadb_exporter.secrets_manager.boto3.session')
+    def test_get_db_credentials_secret_request_error(self, mock_boto3, mock_requests):
+        mock_ec2_response = mock.Mock()
+        mock_requests.get.return_value = mock_ec2_response
+        mock_ec2_response.json.return_value = json.loads('{"region":"test_region"}')
+        mock_session = mock.Mock()
+        mock_sm_client = mock.Mock()
+        mock_boto3.Session.return_value = mock_session
+        mock_session.client.return_value = mock_sm_client
+        mock_sm_client.get_secret_value.side_effect = ClientError({}, "test_operation")
+
+        with pytest.raises(secrets_manager.SecretsManagerError) as err:
+            secrets_manager.get_db_credentials("test_secret")
+        assert 'Couldn\'t retrieve secret details' in str(err.value)


### PR DESCRIPTION
### AWS Secrets Manager (SM) Integration
- **A new config** is added to contains the secret name `aws_secret_name`
- Exporter will use AWS python SDK lib `boto3` to read the region and get the secret values. 
- [Secret string](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html#SecretsManager-GetSecretValue-response-SecretString) is in JSON format and has these key-values `["username" - "password"]`

**Config example**
```
{
  "exposition_port": 9668,
  "multi_tenant": true,
  "timeout": 600,
  "hana": {
    "host": "localhost",
    "port": 30013,
    "aws_secret_name": "HANA_DB_CREDS",
    "user": "SYSTEM",
    "password" : "test_pass"
  }
}
```

**Successful SM connection:** 

```
INFO:__main__:AWS secret name is going to be used to read the database username and password
INFO:hanadb_exporter.secrets_manager:retrieving AWS secret details
INFO:hanadb_exporter.db_manager:user/password combination will be used to connect to the database
```

**Failed SM connection:**

```
botocore.errorfactory.ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/python3/lib/python3.4/site-packages/hanadb_exporter/main.py", line 177, in <module>
    run()
  File "/opt/python3/lib/python3.4/site-packages/hanadb_exporter/main.py", line 149, in run
    db_credentials = secrets_manager.get_db_credentials(aws_secret_name)
  File "/opt/python3/lib/python3.4/site-packages/hanadb_exporter/secrets_manager.py", line 56, in get_db_credentials
    raise SecretsManagerError("Couldn't retrieve secret details") from e
hanadb_exporter.secrets_manager.SecretsManagerError: Couldn't retrieve secret details
```
**username/password connection (current use-case):**

```
INFO:hanadb_exporter.db_manager:user/password combination will be used to connect to the database
```

**Empty secret config:** 

username and password was used as they were provided
```
{
  "exposition_port": 9668,
  "multi_tenant": true,
  "timeout": 600,
  "hana": {
    "host": "localhost",
    "port": 30013,
    "aws_secret_name": "",
    "user": "SYSTEM",
    "password" : "test_pass"
  }
}
```


```
INFO:shaptools.hdb_connector.connectors.base_connector:pyhdb package loaded
INFO:hanadb_exporter.db_manager:user/password combination will be used to connect to the database
```