### PR TITLE
Fix Boto3 dependency introduced by PR#97

### DIFF
--- a/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
+++ b/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
@@ -42,6 +42,7 @@ BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
 Requires:       python3-prometheus_client >= 0.6.0
 Requires:       python3-shaptools >= 0.3.2
+Requires:       python3-boto3
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
The https://github.com/SUSE/hanadb_exporter/pull/97 has introduced the Boto3 dependency. Even that agreed that the RPM changelog and adaptations would be done later, it has broken the HA-SAP automated deployments on the `develop` branch.

This PR is a small fix to re-establish the develop deployment until this new feature is officially released. 