### PR TITLE
Add config option 'listen_address'

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ zypper in python3-PyHDB
 Create the `config.json` configuration file.
 An example of `config.json` available in [config.json.example](config.json.example). Here the most
 important items in the configuration file:
+  - `listen_address`: Address where the prometheus exporter will be exposed (0.0.0.0 by default).
   - `exposition_port`: Port where the prometheus exporter will be exposed (9968 by default).
   - `multi_tenant`: Export the metrics from other tenants. To use this the connection must be done with the System Database (port 30013).
   - `timeout`: Timeout to connect to the database. After this time the app will fail (even in daemon mode).

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+  "listen_address": "0.0.0.0",
   "exposition_port": 9668,
   "multi_tenant": true,
   "timeout": 30,

--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -169,7 +169,7 @@ def run():
     LOGGER.info('exporter successfully registered')
 
     LOGGER.info('starting to serve metrics')
-    start_http_server(config.get('exposition_port', 9668), '0.0.0.0')
+    start_http_server(config.get('exposition_port', 9668), config.get('listen_address', '0.0.0.0'))
     while True:
         time.sleep(1)
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -139,6 +139,7 @@ class TestMain(object):
         mock_parse_arguments.return_value = mock_arguments
 
         config = {
+            'listen_address': '127.0.0.1',
             'hana': {
                 'host': '10.10.10.10',
                 'port': 1234,
@@ -180,7 +181,7 @@ class TestMain(object):
             mock.call('exporter successfully registered'),
             mock.call('starting to serve metrics')
         ])
-        mock_start_server.assert_called_once_with(9668, '0.0.0.0')
+        mock_start_server.assert_called_once_with(9668, '127.0.0.1')
         mock_sleep.assert_called_once_with(1)
         assert mock_systemd.call_count == 0
 


### PR DESCRIPTION
HANADB, Prometheus and hanadb_exporter are used on a single host in our environment. Our security guidelines enforce us to prevent access to the hanadb_exporter metrics endpoint from other systems.
This PR implements the configuration variable listen_address to allow binding on specifiy ip addresses or localhost.