### PR TITLE
update spec file to python packaging best practices

### DIFF
--- a/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
+++ b/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
@@ -37,6 +37,7 @@ URL:            https://github.com/SUSE/hanadb_exporter
 Source:         %{name}-%{version}.tar.gz
 %if %{with test}
 BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module boto3}
 %endif
 BuildRequires:  %{python_module setuptools}
 BuildRequires:  python-rpm-macros

--- a/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
+++ b/packaging/obs/prometheus-hanadb_exporter/prometheus-hanadb_exporter.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package prometheus-hanadb_exporter
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -13,6 +13,7 @@
 # published by the Open Source Initiative.
 
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
 
 %if 0%{?suse_version} < 1500
 %bcond_with test
@@ -23,7 +24,9 @@
 %define _prefix /usr
 %define oldsyscondir /etc
 %define _sysconfdir %{_prefix}/etc
+%define pythons python3
 
+%{?!python_module:%define python_module() python3-%{**}}
 Name:           prometheus-hanadb_exporter
 Version:        0
 Release:        0
@@ -33,16 +36,17 @@ Group:          System/Monitoring
 URL:            https://github.com/SUSE/hanadb_exporter
 Source:         %{name}-%{version}.tar.gz
 %if %{with test}
-BuildRequires:  python3-pytest
+BuildRequires:  %{python_module pytest}
 %endif
-BuildRequires:  python3-setuptools
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  python-rpm-macros
 Provides:       hanadb_exporter = %{version}-%{release}
 BuildRequires:  fdupes
 BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
-Requires:       python3-prometheus_client >= 0.6.0
-Requires:       python3-shaptools >= 0.3.2
-Requires:       python3-boto3
+Requires:       %{python_module prometheus_client} >= 0.6.0
+Requires:       %{python_module shaptools}
+Requires:       %{python_module boto3}
 BuildArch:      noarch
 
 %description
@@ -54,13 +58,13 @@ SAP HANA database metrics exporter
 %setup -q -n %{name}-%{version}
 
 %build
-python3 setup.py build
+%python_build
 
 %install
-python3 setup.py install --root %{buildroot} --prefix=%{_prefix}
-%fdupes %{buildroot}%{python3_sitelib}
+%python_install
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
 # do not install tests
-rm -r %{buildroot}%{python3_sitelib}/tests
+%python_expand rm -r %{buildroot}%{$python_sitelib}/tests
 
 # Add daemon files
 mkdir -p %{buildroot}%{oldsyscondir}/%{shortname}
@@ -100,7 +104,7 @@ pytest tests
 %doc README.md docs/METRICS.md
 %license LICENSE
 %endif
-%{python3_sitelib}/*
+%{python_sitelib}/*
 %{_bindir}/%{shortname}
 
 %dir %{_sysconfdir}


### PR DESCRIPTION
This should fix most of the build errors currently happening at https://build.opensuse.org/package/live_build_log/network:ha-clustering:sap-deployments:devel/prometheus-hanadb_exporter/SLE_15_SP2/x86_64.

e.g.
```
[   66s] copying build/scripts-3.6/hanadb_exporter -> /home/abuild/rpmbuild/BUILDROOT/prometheus-hanadb_exporter-0.7.3+git.dev23.1638430135.5dc78fa-21.2.x86_64/usr/bin
[   66s] changing mode of /home/abuild/rpmbuild/BUILDROOT/prometheus-hanadb_exporter-0.7.3+git.dev23.1638430135.5dc78fa-21.2.x86_64/usr/bin/hanadb_exporter to 755
[   67s] + _target=
[   67s] + _symlinks=0
[   67s] + read _file
[   67s] + fdupes -q -p -n -H -o name -r '/home/abuild/rpmbuild/BUILDROOT/prometheus-hanadb_exporter-0.7.3+git.dev23.1638430135.5dc78fa-21.2.x86_64%{python3_sitelib}'
[   67s]                                         
fdupes: could not chdir to /home/abuild/rpmbuild/BUILDROOT/prometheus-hanadb_exporter-0.7.3+git.dev23.1638430135.5dc78fa-21.2.x86_64%{python3_sitelib}
[   67s] + rm -r '/home/abuild/rpmbuild/BUILDROOT/prometheus-hanadb_exporter-0.7.3+git.dev23.1638430135.5dc78fa-21.2.x86_64%{python3_sitelib}/tests'
[   67s] rm: cannot remove '/home/abuild/rpmbuild/BUILDROOT/prometheus-hanadb_exporter-0.7.3+git.dev23.1638430135.5dc78fa-21.2.x86_64%{python3_sitelib}/tests': No such file or directory
[   67s] error: Bad exit status
```

Look at https://build.opensuse.org/package/show/home:waldt:branches:network:ha-clustering:sap-deployments:devel/prometheus-hanadb_exporter for an example build.