### PR TITLE
Fix the unittest fixing pytest to version 6 by now

### DIFF
--- a/hanadb_exporter/main.py
+++ b/hanadb_exporter/main.py
@@ -139,13 +139,14 @@ def run():
     try:
         hana_config = config['hana']
         dbs = db_manager.DatabaseManager()
-        user=hana_config.get('user', '')
-        password=hana_config.get('password', '')
-        userkey=hana_config.get('userkey', None)
-        aws_secret_name=hana_config.get('aws_secret_name', '')
+        user = hana_config.get('user', '')
+        password = hana_config.get('password', '')
+        userkey = hana_config.get('userkey', None)
+        aws_secret_name = hana_config.get('aws_secret_name', '')
 
         if aws_secret_name:
-            LOGGER.info('AWS secret name is going to be used to read the database username and password')
+            LOGGER.info(
+                'AWS secret name is going to be used to read the database username and password')
             db_credentials = secrets_manager.get_db_credentials(aws_secret_name)
             user = db_credentials["username"]
             password = db_credentials["password"]

--- a/tests/db_manager_test.py
+++ b/tests/db_manager_test.py
@@ -221,7 +221,7 @@ class TestDatabaseManager(object):
             'userkey': None, 'user': 'user', 'password': 'pass', 'RECONNECT': 'FALSE',
             'encrypt': True, 'sslValidateCertificate': True, 'sslTrustStore': 'my.pem'}
         logger.assert_has_calls([
-            mock.call('user/password combination will be used to connect to the databse'),
+            mock.call('user/password combination will be used to connect to the database'),
             mock.call('Using ssl connection...')
         ])
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -358,7 +358,7 @@ class TestMain(object):
         mock_db_manager.assert_called_once_with()
         db_instance.start.assert_called_once_with(
             '10.10.10.10', 1234, user='db_user', password='db_pass',
-            userkey=None, multi_tenant=True, timeout=30)
+            userkey=None, multi_tenant=True, timeout=30, ssl=False, ssl_validate_cert=False)
         db_instance.get_connectors.assert_called_once_with()
         mock_exporters.assert_called_once_with(
             connectors='connectors', metrics_file='metrics')

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist = py{36,38},pylint
 
 [testenv]
 deps =
-    pytest
+    pytest~=6.0
+    boto3
 
 commands =
     py.test tests -vv {posargs}


### PR DESCRIPTION
Fix pytest to version 6.x by now. They have released version 7, which breaks the current test, so moving 1 version back helps us temporarily.