### PR TITLE
IMDSv1 and IMDSv2 abstraction for the retrieval of HANA DB Credentials from AWS Secrets Manager

### DIFF
--- a/.github/workflows/exporter-ci.yml
+++ b/.github/workflows/exporter-ci.yml
@@ -21,7 +21,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # TODO: Pending fix of https://github.com/SUSE/hanadb_exporter/issues/113
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.8]

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -55,17 +55,22 @@ def get_db_credentials(secret_name):
 
     # Create a Secrets Manager client
     session = boto3.session.Session()
-    client = session.client(service_name="secretsmanager", region_name=region_name)
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
 
     # In this sample we only handle the specific exceptions for the 'GetSecretValue' API.
     # See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
     # We rethrow the exception by default.
 
     try:
-        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
     except ClientError as e:
         raise SecretsManagerError("Couldn't retrieve secret details") from e
     else:
         # Decrypts secret using the associated KMS CMK.]
-        secret = get_secret_value_response["SecretString"]
+        secret = get_secret_value_response['SecretString']
         return json.loads(secret)

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -32,7 +32,7 @@ def get_db_credentials(secret_name):
     ec2_info_response = requests.get(EC2_INFO_URL)
 
     # In case the EC2 instance is making use of IMDSv2, calls to the EC2 instance metadata data service will return 401 Unauthorized HTTP Return code.
-    # In this case, python catches the error, generates an authentication token before re-attempting the call to the EC2 instance metadata service.
+    # In this case, python catches the error, generates an authentication token before attempting the call to the EC2 instance metadata service again using IMDSv2.
     if ec2_info_response.status_code == 401:
             ec2_metadata_service_token = requests.put(
                 TOKEN_URL, headers=TOKEN_HEADER

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -34,9 +34,12 @@ def get_db_credentials(secret_name):
     # In case the EC2 instance is making use of IMDSv2, calls to the EC2 instance metadata data service will return 401 Unauthorized HTTP Return code.
     # In this case, python catches the error, generates an authentication token before attempting the call to the EC2 instance metadata service again using IMDSv2.
     if ec2_info_response.status_code == 401:
-            ec2_metadata_service_token = requests.put(
-                TOKEN_URL, headers=TOKEN_HEADER
-            ).content
+            try:
+                ec2_metadata_service_token = requests.put(
+                    TOKEN_URL, headers=TOKEN_HEADER
+                ).content
+            except HTTPError as e:
+                raise SecretsManagerError("EC2 instance metadata service request failed") from e
             ec2_info_response = requests.get(
                 EC2_INFO_URL,
                 headers={"X-aws-ec2-metadata-token": ec2_metadata_service_token},

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -31,6 +31,8 @@ def get_db_credentials(secret_name):
 
     ec2_info_response = requests.get(EC2_INFO_URL)
 
+    # In case the EC2 instance is making use of IMDSv2, calls to the EC2 instance metadata data service will return 401 Unauthorized HTTP Return code.
+    # In this case, python catches the error, generates an authentication token before re-attempting the call to the EC2 instance metadata service.
     if ec2_info_response.status_code == 401:
             ec2_metadata_service_token = requests.put(
                 TOKEN_URL, headers=TOKEN_HEADER

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -10,7 +10,6 @@ import json
 import logging
 
 import boto3
-import requests
 from ec2_metadata import ec2_metadata
 from botocore.exceptions import ClientError
 from requests.exceptions import HTTPError

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -12,7 +12,6 @@ import logging
 import boto3
 from ec2_metadata import ec2_metadata
 from botocore.exceptions import ClientError
-from requests.exceptions import HTTPError
 
 LOGGER = logging.getLogger(__name__)
 

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -34,16 +34,17 @@ def get_db_credentials(secret_name):
     # In case the EC2 instance is making use of IMDSv2, calls to the EC2 instance metadata data service will return 401 Unauthorized HTTP Return code.
     # In this case, python catches the error, generates an authentication token before attempting the call to the EC2 instance metadata service again using IMDSv2.
     if ec2_info_response.status_code == 401:
-            try:
-                ec2_metadata_service_token = requests.put(
-                    TOKEN_URL, headers=TOKEN_HEADER
-                ).content
-            except HTTPError as e:
-                raise SecretsManagerError("EC2 instance metadata service request failed") from e
-            ec2_info_response = requests.get(
-                EC2_INFO_URL,
-                headers={"X-aws-ec2-metadata-token": ec2_metadata_service_token},
-            )
+        try:
+            ec2_metadata_service_token = requests.put(
+                TOKEN_URL, headers=TOKEN_HEADER
+            ).content
+        except HTTPError as e:
+            raise SecretsManagerError("EC2 instance metadata service request failed") from e
+
+        ec2_info_response = requests.get(
+            EC2_INFO_URL,
+            headers={"X-aws-ec2-metadata-token": ec2_metadata_service_token},
+        )
             
     try:
         ec2_info_response.raise_for_status()

--- a/hanadb_exporter/secrets_manager.py
+++ b/hanadb_exporter/secrets_manager.py
@@ -31,8 +31,11 @@ def get_db_credentials(secret_name):
 
     ec2_info_response = requests.get(EC2_INFO_URL)
 
-    # In case the EC2 instance is making use of IMDSv2, calls to the EC2 instance metadata data service will return 401 Unauthorized HTTP Return code.
-    # In this case, python catches the error, generates an authentication token before attempting the call to the EC2 instance metadata service again using IMDSv2.
+    # In case the EC2 instance is making use of IMDSv2, calls to the EC2 instance
+    # metadata data service will return 401 Unauthorized HTTP Return code.
+    # In this case, python catches the error, generates an authentication token
+    # before attempting the call to the EC2 instance metadata service again using
+    # the IMDSv2 token authentication header.
     if ec2_info_response.status_code == 401:
         try:
             ec2_metadata_service_token = requests.put(
@@ -45,7 +48,7 @@ def get_db_credentials(secret_name):
             EC2_INFO_URL,
             headers={"X-aws-ec2-metadata-token": ec2_metadata_service_token},
         )
-            
+
     try:
         ec2_info_response.raise_for_status()
     except HTTPError as e:

--- a/tests/secrets_manager_test.py
+++ b/tests/secrets_manager_test.py
@@ -49,31 +49,6 @@ class TestSecretsManager(object):
         assert actual_secret['username'] == 'db_user'
         assert actual_secret['password'] == 'db_pass'
 
-    @mock.patch('hanadb_exporter.secrets_manager.LOGGER')
-    @mock.patch('hanadb_exporter.secrets_manager.requests')
-    @mock.patch('hanadb_exporter.secrets_manager.boto3.session')
-    def test_get_db_credentials_imdsv2(self, mock_boto3, mock_requests, mock_logger):
-        mock_ec2_response = mock.Mock()
-        mock_requests.get.return_value = mock_ec2_response
-        mock_requests.get.return_value.status_code = 401
-        mock_ec2_response.json.return_value = json.loads('{"region":"test_region_imdsv2"}')
-        mock_session = mock.Mock()
-        mock_sm_client = mock.Mock()
-        mock_boto3.Session.return_value = mock_session
-        mock_session.client.return_value = mock_sm_client
-        mock_sm_client.get_secret_value.return_value = json.loads(
-            '{"SecretString" : "{\\"username\\": \\"db_user\\", \\"password\\":\\"db_pass\\"}"}')
-
-        actual_secret = secrets_manager.get_db_credentials("test_secret")
-
-        mock_session.client.assert_called_once_with(service_name='secretsmanager', region_name='test_region_imdsv2')
-        mock_sm_client.get_secret_value.assert_called_once_with(SecretId='test_secret')
-        mock_logger.info.assert_has_calls([
-            mock.call('retrieving AWS secret details')
-        ])
-        assert actual_secret['username'] == 'db_user'
-        assert actual_secret['password'] == 'db_pass'
-    
     @mock.patch('hanadb_exporter.secrets_manager.requests')
     def test_get_db_credentials_ec2_request_error(self, mock_requests):
         ec2_info_response = mock.Mock()

--- a/tests/secrets_manager_test.py
+++ b/tests/secrets_manager_test.py
@@ -49,6 +49,31 @@ class TestSecretsManager(object):
         assert actual_secret['username'] == 'db_user'
         assert actual_secret['password'] == 'db_pass'
 
+    @mock.patch('hanadb_exporter.secrets_manager.LOGGER')
+    @mock.patch('hanadb_exporter.secrets_manager.requests')
+    @mock.patch('hanadb_exporter.secrets_manager.boto3.session')
+    def test_get_db_credentials_imdsv2(self, mock_boto3, mock_requests, mock_logger):
+        mock_ec2_response = mock.Mock()
+        mock_requests.get.return_value = mock_ec2_response
+        mock_requests.get.return_value.status_code = 401
+        mock_ec2_response.json.return_value = json.loads('{"region":"test_region_imdsv2"}')
+        mock_session = mock.Mock()
+        mock_sm_client = mock.Mock()
+        mock_boto3.Session.return_value = mock_session
+        mock_session.client.return_value = mock_sm_client
+        mock_sm_client.get_secret_value.return_value = json.loads(
+            '{"SecretString" : "{\\"username\\": \\"db_user\\", \\"password\\":\\"db_pass\\"}"}')
+
+        actual_secret = secrets_manager.get_db_credentials("test_secret")
+
+        mock_session.client.assert_called_once_with(service_name='secretsmanager', region_name='test_region_imdsv2')
+        mock_sm_client.get_secret_value.assert_called_once_with(SecretId='test_secret')
+        mock_logger.info.assert_has_calls([
+            mock.call('retrieving AWS secret details')
+        ])
+        assert actual_secret['username'] == 'db_user'
+        assert actual_secret['password'] == 'db_pass'
+    
     @mock.patch('hanadb_exporter.secrets_manager.requests')
     def test_get_db_credentials_ec2_request_error(self, mock_requests):
         ec2_info_response = mock.Mock()

--- a/tests/secrets_manager_test.py
+++ b/tests/secrets_manager_test.py
@@ -59,9 +59,7 @@ class TestSecretsManager(object):
         mock_ec2_response = mock.Mock()
         mock_ec2_response.json.return_value = json.loads('{"region":"test_region_imdsv2"}')
 
-        mock_requests.get.return_value = mock_ec2_response
-        mock_requests.get.return_value.status_code = 401
-        mock_requests.get.side_effects = [mock_ec2_unauthorized, mock_ec2_response]
+        mock_requests.get.side_effect = [mock_ec2_unauthorized, mock_ec2_response]
 
         mock_ec2_put = mock.Mock()
         mock_ec2_put.content = 'my-test-token'

--- a/tests/secrets_manager_test.py
+++ b/tests/secrets_manager_test.py
@@ -1,7 +1,7 @@
 """
 Unitary tests for exporters/secrets_manager.py.
 
-:author: elturkym
+:author: elturkym, schniber
 
 :since: 2021-07-15
 """
@@ -49,6 +49,31 @@ class TestSecretsManager(object):
         assert actual_secret['username'] == 'db_user'
         assert actual_secret['password'] == 'db_pass'
 
+    @mock.patch('hanadb_exporter.secrets_manager.LOGGER')
+    @mock.patch('hanadb_exporter.secrets_manager.requests')
+    @mock.patch('hanadb_exporter.secrets_manager.boto3.session')
+    def test_get_db_credentials_imdsv2(self, mock_boto3, mock_requests, mock_logger):
+        mock_ec2_response = mock.Mock()
+        mock_requests.get.return_value = mock_ec2_response
+        mock_requests.get.return_value.status_code = 401
+        mock_ec2_response.json.return_value = json.loads('{"region":"test_region_imdsv2"}')
+        mock_session = mock.Mock()
+        mock_sm_client = mock.Mock()
+        mock_boto3.Session.return_value = mock_session
+        mock_session.client.return_value = mock_sm_client
+        mock_sm_client.get_secret_value.return_value = json.loads(
+            '{"SecretString" : "{\\"username\\": \\"db_user\\", \\"password\\":\\"db_pass\\"}"}')
+
+        actual_secret = secrets_manager.get_db_credentials("test_secret")
+
+        mock_session.client.assert_called_once_with(service_name='secretsmanager', region_name='test_region_imdsv2')
+        mock_sm_client.get_secret_value.assert_called_once_with(SecretId='test_secret')
+        mock_logger.info.assert_has_calls([
+            mock.call('retrieving AWS secret details')
+        ])
+        assert actual_secret['username'] == 'db_user'
+        assert actual_secret['password'] == 'db_pass'
+    
     @mock.patch('hanadb_exporter.secrets_manager.requests')
     def test_get_db_credentials_ec2_request_error(self, mock_requests):
         ec2_info_response = mock.Mock()

--- a/tests/secrets_manager_test.py
+++ b/tests/secrets_manager_test.py
@@ -83,13 +83,17 @@ class TestSecretsManager(object):
             mock.call('retrieving AWS secret details')
         ])
 
+        mock_requests.get.assert_has_calls([
+            mock.call("http://169.254.169.254/latest/dynamic/instance-identity/document"),
+            mock.call("http://169.254.169.254/latest/dynamic/instance-identity/document",
+                      headers={'X-aws-ec2-metadata-token': 'my-test-token'})
+        ])
+
+        mock_requests.put.assert_called_with("http://169.254.169.254/latest/api/token",
+                                             headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"})
+
         assert actual_secret['username'] == 'db_user'
         assert actual_secret['password'] == 'db_pass'
-
-        mock_requests.get.assert_called_with(
-            'http://169.254.169.254/latest/dynamic/instance-identity/document',
-            headers={'X-aws-ec2-metadata-token': 'my-test-token'}
-        )
 
     @mock.patch('hanadb_exporter.secrets_manager.requests')
     def test_get_db_credentials_ec2_request_error(self, mock_requests):


### PR DESCRIPTION
Hello,

This is a proposed quickfix for #111 that allows the use of the python library ec2-metadata to read the region name as opposed to querying the instance metadata services directly with the requests library.

This will allow users running on EC2 instances that are configure to use IMDSv2 (as well as IMDSv1) to use the prometheus hana db exporter while safely storing the HANA DB Credentials in AWS Secrets Manager.

Thanks for your peer review.

Bests.